### PR TITLE
Roles

### DIFF
--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -1,0 +1,18 @@
+# Extract URLs from Messages
+
+Provides two methods that allow you to easily extract hyperlinks from messages. Supports
+
+*   both plain links and message entities,
+*   both normal messages and captions,
+*   extracting solely direct links to Telegram messages.
+
+Please see the docstrings for more details.
+
+## Requirements
+
+*   `python-telegram-bot>=12.0`
+
+## Authors
+
+*   [Joscha Götzer](https://github.com/josxa)
+*   [Hinrich Mahler](https://github.com/bibo-joshi)

--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -50,10 +50,10 @@ dp.add_handler(RolesHandler(SomeHandler(...), roles=roles.CHAT_ADMINS))
 dp.add_handler(RolesHandler(SomeHandler(...), roles=roles.CHAT_CREATOR))
 
 # You can compare the roles regarding hierarchy:
-roles.ADMINS >=  roles['my_role_1'] #True
-roles.ADMINS >=  roles['my_role_2'] #True
-roles['my_role_1'] < roles['my_role_2'] #False
-roles.ADMINS >= Role(...) #False, since neither of those is a parent of the other
+roles.ADMINS >=  roles['my_role_1']  # True
+roles.ADMINS >=  roles['my_role_2']  # True
+roles['my_role_1'] < roles['my_role_2']  # False
+roles.ADMINS >= Role(...)  # False, since neither of those is a parent of the other
 ```
 
 Please see the docstrings for more details.

--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -1,18 +1,67 @@
-# Extract URLs from Messages
+# Dynamic User Access Management
 
-Provides two methods that allow you to easily extract hyperlinks from messages. Supports
+Provides classes and methods for granular, hierarchical user access management. Example:
 
-*   both plain links and message entities,
-*   both normal messages and captions,
-*   extracting solely direct links to Telegram messages.
+```python
+from telegram import Update
+from telegram.ext import Updater, TypeHandler, Filters, MessageHandler, SomeHandler
+from ptbcontrib.roles import setup_roles, RolesHandler, Role
+
+updater = Updater('TOKEN')
+dp = updater.dispatcher
+roles = setup_roles(dp)
+
+roles.add_admin('authors_user_id')
+roles.add_role(name='my_role_1')
+my_role_1 = roles['my_role_1']
+roles.add_role(name='my_role_2')
+my_role_2 = roles['my_role_2']
+my_role_1.add_child_role(my_role_2)
+
+def add_to_my_role_2(update, context):
+    user = update.effective_user
+    context.roles['my_role_2'].add_member(user.id)
+    
+def add_to_my_role_1(update, context):
+    user_id = int(update.message.text)
+    context.roles['my_role_1'].add_member(user_id)
+
+...
+
+# Anyone can add themself to my_role_2
+dp.add_handler(TypeHandler(Update, add_to_my_role_2))
+
+# Only the admin can add users to my_role_1
+dp.add_handler(RolesHandler(MessageHandler(Filters.message, add_to_my_role_1), roles=roles.ADMINS))
+
+# This will be accessible by my_role_2, my_role_1 and the admin
+dp.add_handler(RolesHandler(SomeHandler(...), roles=my_role_2))
+
+# This will be accessible by my_role_1 and the admin
+dp.add_handler(RolesHandler(SomeHandler(...), roles=my_role_1))
+
+# This will be accessible by anyone except my_role_1 and my_role_2
+dp.add_handler(RolesHandler(SomeHandler(...), roles=~my_role_1))
+
+# This will be accessible only by the admins of the group the update was sent in
+dp.add_handler(RolesHandler(SomeHandler(...), roles=roles.CHAT_ADMINS))
+
+# This will be accessible only by the creator of the group the update was sent in
+dp.add_handler(RolesHandler(SomeHandler(...), roles=roles.CHAT_CREATOR))
+
+# You can compare the roles regarding hierarchy:
+roles.ADMINS >=  roles['my_role_1'] #True
+roles.ADMINS >=  roles['my_role_2'] #True
+roles['my_role_1'] < roles['my_role_2'] #False
+roles.ADMINS >= Role(...) #False, since neither of those is a parent of the other
+```
 
 Please see the docstrings for more details.
 
 ## Requirements
 
-*   `python-telegram-bot>=12.0`
+*   `python-telegram-bot>=13.1`
 
 ## Authors
 
-*   [Joscha Götzer](https://github.com/josxa)
 *   [Hinrich Mahler](https://github.com/bibo-joshi)

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains helper functions to extract URLs from messages."""
+"""This module contains classes and methods for granular, hierarchical user access management."""
 
 from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole, InvertedRole
 from .roleshandler import RolesHandler, setup_roles, BOT_DATA_KEY

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -16,6 +16,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains helper functions to extract URLs from messages."""
 
-from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole
+from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole, InvertedRole
 
-__all__ = ['Roles', 'Role', 'ChatCreatorRole', 'ChatAdminsRole']
+__all__ = ['Roles', 'Role', 'ChatCreatorRole', 'ChatAdminsRole', 'InvertedRole']

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -1,0 +1,21 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains helper functions to extract URLs from messages."""
+
+from .roles import extract_urls, extract_message_links
+
+__all__ = ['extract_urls', 'extract_message_links']

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -16,6 +16,6 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains helper functions to extract URLs from messages."""
 
-from .roles import extract_urls, extract_message_links
+from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole
 
-__all__ = ['extract_urls', 'extract_message_links']
+__all__ = ['Roles', 'Role', 'ChatCreatorRole', 'ChatAdminsRole']

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -17,5 +17,15 @@
 """This module contains helper functions to extract URLs from messages."""
 
 from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole, InvertedRole
+from .roleshandler import RolesHandler, setup_roles, BOT_DATA_KEY
 
-__all__ = ['Roles', 'Role', 'ChatCreatorRole', 'ChatAdminsRole', 'InvertedRole']
+__all__ = [
+    'Roles',
+    'Role',
+    'ChatCreatorRole',
+    'ChatAdminsRole',
+    'InvertedRole',
+    'RolesHandler',
+    'setup_roles',
+    'BOT_DATA_KEY',
+]

--- a/ptbcontrib/roles/requirements.txt
+++ b/ptbcontrib/roles/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=12.8

--- a/ptbcontrib/roles/requirements.txt
+++ b/ptbcontrib/roles/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot>=13.1
+python-telegram-bot>=13.0

--- a/ptbcontrib/roles/requirements.txt
+++ b/ptbcontrib/roles/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot>=12.8
+python-telegram-bot>=13.1

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -18,19 +18,19 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains the class Role, which allows to restrict access to handlers."""
 import time
-
-try:
-    import ujson as json
-except ImportError:
-    import json
+from collections.abc import Mapping
+from threading import Lock, BoundedSemaphore
+from typing import ClassVar, Union, List, Set, Tuple, FrozenSet, Optional, Dict, Any, Iterator
 
 from copy import deepcopy
 
-from telegram import ChatMember, TelegramError, Bot, Chat
-from telegram.ext import Filters
+from telegram import ChatMember, TelegramError, Bot, Chat, Update
+from telegram.ext import Filters, UpdateFilter
 
 
-class Role(Filters.chat):
+# Order of the base classes matter, as Filters.chat is a MessageFilter, but we want to
+# misuse it as UpdateFilter
+class Role(UpdateFilter, Filters.chat):
     """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
     hierarchy, i.e. a role can do everthing, its child roles can do. To compare two roles you may
     use the following syntax::
@@ -104,124 +104,143 @@ class Role(Filters.chat):
         chat_ids (set(:obj:`int`)): The ids of the users/chats of this role. Updates
             will only be parsed, if the id of :attr:`telegram.Update.effective_user` or
             :attr:`telegram.Update.effective_chat` respectiveley is listed here. May be empty.
-        parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
-            roles can do anything, this role can do. May be empty.
-        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
-            anything, its child roles can do. May be empty.
 
     Args:
         chat_ids (:obj:`int` | iterable(:obj:`int`), optional): The ids of the users/chats of this
             role. Updates will only be parsed, if the id of :attr:`telegram.Update.effective_user`
             or :attr:`telegram.Update.effective_chat` respectiveley is listed here.
-        parent_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`)), optional):
-            Parent roles of this role.
         child_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`)), optional):
             Child roles of this role.
         name (:obj:`str`, optional): A name for this role.
     """
 
-    update_filter = True
+    __admin_lock = Lock()
+    __admin_semaphore = BoundedSemaphore()
+    __admin: ClassVar['Role'] = None  # type: ignore[assignment]
 
-    def __init__(self, chat_ids=None, parent_roles=None, child_roles=None, name=None):
-        if chat_ids is None:
-            chat_ids = []
+    def __init__(
+        self,
+        chat_ids: Union[int, List[int], Tuple[int, ...]] = None,
+        child_roles: Union['Role', List['Role'], Tuple['Role', ...]] = None,
+        name: str = None,
+    ) -> None:
         super().__init__(chat_ids)
         self.name = name
-
-        self.parent_roles = set()
-        if isinstance(parent_roles, Role):
-            self.add_parent_role(parent_roles)
-        elif parent_roles is not None:
-            for pr in parent_roles:
-                self.add_parent_role(pr)
-
-        self.child_roles = set()
-        if isinstance(child_roles, Role):
-            self.add_child_role(child_roles)
-        elif child_roles is not None:
-            for cr in child_roles:
-                self.add_child_role(cr)
-
         self._inverted = False
+        self.__lock = Lock()
 
-    def __invert__(self):
-        self._inverted = True
-        return ~self
+        self._child_roles: Set['Role'] = set()
+        self._set_child_roles(child_roles)
 
-    def filter_children(self, user, chat):
-        # filters only downward
-        if user and user.id in self.chat_ids:
-            return True
-        if chat and chat.id in self.chat_ids:
-            return True
-        if any([child.filter_children(user, chat) for child in self.child_roles]):
-            return True
+        if self.__admin_semaphore.acquire(blocking=False):
+            self.__init_admin()
+        # We need the if clause for the init of __admin
+        if self.__admin is not None:
+            self.__admin.add_child_role(self)
 
-    def filter(self, update):
+    @classmethod
+    def __init_admin(cls) -> None:
+        with cls.__admin_lock:
+            if cls.__admin is None:
+                cls.__admin__admin = cls(name='admins')
+
+    def _set_custom_admin(self, new_admin: 'Role') -> None:
+        with self.__admin_lock:
+            self.__admin.remove_child_role(self)
+        new_admin.add_child_role(self)
+
+    @staticmethod
+    def _parse_child_role(
+        child_role: Union['Role', List['Role'], Tuple['Role', ...], None]
+    ) -> Set['Role']:
+        if child_role is None:
+            return set()
+        if isinstance(child_role, Role):
+            return {child_role}
+        return set(child_role)
+
+    def _set_child_roles(
+        self, child_role: Union['Role', List['Role'], Tuple['Role', ...], None]
+    ) -> None:
+        with self.__lock:
+            self._child_roles = self._parse_child_role(child_role)
+
+    @property
+    def child_roles(self) -> FrozenSet['Role']:
+        """Child roles of this role. This role can do anything, its child roles can do.
+        May be empty.
+
+        Returns:
+            Set(:class:`telegram.ext.Role`):
+        """
+        with self.__lock:
+            return frozenset(self._child_roles)
+
+    def __invert__(self) -> 'Role':
+        inverted_role = ~self
+        inverted_role._inverted = True
+        return inverted_role
+
+    def filter(  # pylint: disable=W0221
+        self, update: Update, target: 'Role' = None
+    ) -> Optional[bool]:
         user = update.effective_user
         chat = update.effective_chat
+
+        # If the update has neither effective chat nor user, we don't handle it
+        if not (user or chat):
+            return False
+
+        # First check if the user/chat is in the current roles allowed chats
         if user and user.id in self.chat_ids:
             return True
         if chat and chat.id in self.chat_ids:
             return True
-        if user or chat:
-            if self._inverted:
-                # If this is an inverted role (i.e. ~role) and we arrived here, the user is
-                # either ...
-                if self.filter_children(user, chat):
-                    # ... in a child role of this. In this case, and must be excluded. Since the
-                    # output of this will be negated, return True
-                    return True
-                # ... not in a child role of this and must *nto* be excluded. In particular, we
-                # dont want to exclude the parents (see below). Since the output of this will be
-                # negated, return False
-                return False
-            else:
-                return any([parent(update) for parent in self.parent_roles])
 
-    def add_member(self, chat_id):
-        """Adds a user/chat to this role. Will do nothing, if user/chat is already present.
+        if self._inverted:
+            # If this is an inverted role (i.e. ~role) and we arrived here, the user is
+            # either
+            # ... in a child role of this. In this case, and must be excluded. Since the
+            # output of this will be negated, return True
+            # ... not in a child role of this and must *not* be excluded. In particular, we
+            # dont want to exclude the parents (see below). Since the output of this will be
+            # negated, return False
+            return any(child.filter(update, target=target) for child in self.child_roles)
+
+        # If we have no result here, we need to check the roles tree in order to check if
+        # a parent role allows us to handle the update
+        if target:
+            root = self
+        else:
+            # The initial call will start looking from the admin parent
+            root = self.__admin
+        # We check all children that are parents of the target role
+        return any(
+            child.filter(update, target=target) for child in root.child_roles if target <= child
+        )
+
+    def add_member(self, chat_id: Union[int, List[int], Tuple[int, ...]]) -> None:
+        """
+        Add one or more chat(s)/user(s) to the allowed chat/user ids. Will do nothing, if user/chat
+        is already present.
 
         Args:
-            chat_id (:obj:`int`): The users/chats id
+            chat_id(:obj:`int` | List[:obj:`int`], optional): Which chat ID(s) to allow
+                through.
         """
         self.add_chat_ids(chat_id)
 
-    def kick_member(self, chat_id):
-        """Kicks a user/chat to from role. Will do nothing, if user/chat is not present.
+    def kick_member(self, chat_id: Union[int, List[int], Tuple[int, ...]]) -> None:
+        """Kicks one ore more user(s)/chat(s) to from role. Will do nothing, if user/chat is not
+        present.
 
         Args:
-            chat_id (:obj:`int`): The users/chats id
+            chat_id(:obj:`int` | List[:obj:`int`], optional): The users/chats id
         """
         self.remove_chat_ids(chat_id)
 
-    def add_parent_role(self, parent_role):
-        """Adds a parent role to this role. Also adds this role to the parents child roles. Will do
-        nothing, if parent role is already present.
-
-        Args:
-            parent_role (:class:`telegram.ext.Role`): The parent role
-        """
-        if self is parent_role:
-            raise ValueError('You must not add a role as its own parent!')
-        if self >= parent_role:
-            raise ValueError('You must not add a child role as a parent!')
-        self.parent_roles.add(parent_role)
-        parent_role.child_roles.add(self)
-
-    def remove_parent_role(self, parent_role):
-        """Removes a parent role from this role. Also removes this role from the parents child
-        roles. Will do nothing, if parent role is not present.
-
-        Args:
-            parent_role (:class:`telegram.ext.Role`): The parent role
-        """
-        self.parent_roles.discard(parent_role)
-        parent_role.child_roles.discard(self)
-
-    def add_child_role(self, child_role):
-        """Adds a child role to this role. Also adds this role to the childs parent roles. Will do
-        nothing, if child role is already present.
+    def add_child_role(self, child_role: 'Role') -> None:
+        """Adds a child role to this role. Will do nothing, if child role is already present.
 
         Args:
             child_role (:class:`telegram.ext.Role`): The child role
@@ -230,50 +249,51 @@ class Role(Filters.chat):
             raise ValueError('You must not add a role as its own child!')
         if self <= child_role:
             raise ValueError('You must not add a parent role as a child!')
-        self.child_roles.add(child_role)
-        child_role.parent_roles.add(self)
+        with self.__lock:
+            self._child_roles |= child_role
 
-    def remove_child_role(self, child_role):
-        """Removes a child role from this role. Also removes this role from the childs parent
-        roles. Will do nothing, if child role is not present.
+    def remove_child_role(self, child_role: 'Role') -> None:
+        """Removes a child role from this role. Will do nothing, if child role is not present.
 
         Args:
             child_role (:class:`telegram.ext.Role`): The child role
         """
-        self.child_roles.discard(child_role)
-        child_role.parent_roles.discard(self)
+        with self.__lock:
+            self._child_roles.discard(child_role)
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         # Test for hierarchical order
         if isinstance(other, Role):
-            return any([pr <= other for pr in self.parent_roles])
+            return self is not other and any(self <= child for child in other.child_roles)
         return False
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> bool:
         # Test for hierarchical order
         return self is other or self < other
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> bool:
         # Test for hierarchical order
         if isinstance(other, Role):
-            return any([self >= pr for pr in other.parent_roles])
+            return self is not other and any(other <= child for child in self.child_roles)
         return False
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> bool:
         # Test for hierarchical order
         return self is other or self > other
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self is other
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def equals(self, other):
+    def equals(self, other: 'Role') -> bool:
         """Test if two roles are equal in terms of hierarchy. Returns :obj:``True``, if the
-        :attr:`chat_ids` coincide and the child roles are equal in terms of this method. Note, that
-        the result of this comparison may change by adding or removing child/parent roles or
-        members.
+        :attr:`chat_ids` coincide and the child roles are equal in terms of this method.
+
+        Note:
+            The result of this comparison may change by adding or removing child roles or
+            members.
 
         Args:
             other (:class:`telegram.ext.Role`):
@@ -285,34 +305,31 @@ class Role(Filters.chat):
             if len(self.child_roles) == len(other.child_roles):
                 if len(self.child_roles) == 0:
                     return True
-                for cr in self.child_roles:
-                    if not any([cr.equals(ocr) for ocr in other.child_roles]):
+                for child_role in self.child_roles:
+                    if not any(child_role.equals(ocr) for ocr in other.child_roles):
                         return False
                 for ocr in other.child_roles:
-                    if not any([ocr.equals(cr) for cr in self.child_roles]):
+                    if not any(ocr.equals(cr) for cr in self.child_roles):
                         return False
                 return True
         return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return id(self)
 
-    def __deepcopy__(self, memo):
-        new_role = Role(chat_ids=self.chat_ids, name=self.name)
+    def __deepcopy__(self, memo: Dict[int, Any]) -> 'Role':
+        new_role = Role(chat_ids=list(self.chat_ids), name=self.name)
         memo[id(self)] = new_role
-        for pr in self.parent_roles:
-            new_role.add_parent_role(deepcopy(pr, memo))
-        for cr in self.child_roles:
-            new_role.add_child_role(deepcopy(cr, memo))
+        for child_role in self.child_roles:
+            new_role.add_child_role(deepcopy(child_role, memo))
         return new_role
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.name:
             return f'Role({self.name})'
-        elif self.chat_ids:
+        if self.chat_ids:
             return f'Role({self.chat_ids})'
-        else:
-            return 'Role({})'
+        return 'Role({})'
 
 
 class ChatAdminsRole(Role):
@@ -331,13 +348,13 @@ class ChatAdminsRole(Role):
             hour).
     """
 
-    def __init__(self, bot, timeout=1800):
+    def __init__(self, bot: Bot, timeout: int = 1800):
         super().__init__(name='chat_admins')
         self.bot = bot
-        self.cache = {}
+        self.cache: Dict[int, Tuple[float, List[int]]] = {}
         self.timeout = timeout
 
-    def filter(self, update):
+    def filter(self, update: Update, target: Role = None) -> Optional[bool]:
         user = update.effective_user
         chat = update.effective_chat
 
@@ -356,8 +373,9 @@ class ChatAdminsRole(Role):
             admins = [m.user.id for m in self.bot.get_chat_administrators(chat.id)]
             self.cache[chat.id] = (time.time(), admins)
             return user.id in admins
+        return False
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Dict[int, Any]) -> Role:
         new_role = super().__deepcopy__(memo)
         new_role.bot = self.bot
         new_role.cache = self.cache
@@ -373,12 +391,12 @@ class ChatCreatorRole(Role):
         bot (:class:`telegram.Bot`): A bot to use for getting the creator of a chat.
     """
 
-    def __init__(self, bot):
+    def __init__(self, bot: Bot) -> None:
         super().__init__(name='chat_creator')
         self.bot = bot
-        self.cache = {}
+        self.cache: Dict[int, Tuple[float, List[int]]] = {}
 
-    def filter(self, update):
+    def filter(self, update: Update, target: Role = None) -> Optional[bool]:
         user = update.effective_user
         chat = update.effective_chat
 
@@ -399,34 +417,33 @@ class ChatCreatorRole(Role):
             except TelegramError:
                 # user is not a chat member or bot has no access
                 return False
+        return False
 
-    def __deepcopy__(self, memo):
-        new_role = super(ChatCreatorRole, self).__deepcopy__(memo)
+    def __deepcopy__(self, memo: Dict[int, Any]) -> 'Role':
+        new_role = super().__deepcopy__(memo)
         new_role.bot = self.bot
         new_role.cache = self.cache
         return new_role
 
 
-class Roles(dict):
+class Roles(Mapping):
     """This class represents a collection of :class:`telegram.ext.Role` s that can be used to
     manage access control to functionality of a bot. Each role can be accessed by its name, e.g.::
-            roles.add_role('my_role')
-            role = roles['my_role']
+
+        roles.add_role('my_role')
+        role = roles['my_role']
 
     Note:
-        In fact, :class:`telegram.ext.Roles` inherits from :obj:`dict` and thus provides most
-        methods needed for the common use cases. Methods that are *not* supported are:
-        ``__delitem__``, ``__setitem__``, ``setdefault``, ``update``, ``pop``, ``popitem``,
-        ``clear`` and ``copy``.
-        Please use :attr:`add_role` and :attr:`remove_role` instead.
+        In fact, :class:`telegram.ext.Roles` is a :class:`collections.Mapping` and as such can be
+        be used almost like a dictionary.
 
     Attributes:
-        ADMINS (:class:`telegram.ext.Role`): A role reserved for administrators of the bot. All
+        admins (:class:`telegram.ext.Role`): A role reserved for administrators of the bot. All
             roles added to this instance will be child roles of :attr:`ADMINS`.
-        CHAT_ADMINS (:class:`telegram.ext.roles.ChatAdminsRole`): Use this role to restrict access
+        chat_admins (:class:`telegram.ext.roles.ChatAdminsRole`): Use this role to restrict access
             to admins of a chat. Handlers with this role wont handle updates that don't have an
             ``effective_chat``. Admins are cached for each chat.
-        CHAT_CREATOR (:class:`telegram.ext.roles.ChatCreatorRole`): Use this role to restrict
+        chat_creator (:class:`telegram.ext.roles.ChatCreatorRole`): Use this role to restrict
             access to the creator of a chat. Handlers with this role wont handle updates that don't
             have an ``effective_chat``.
 
@@ -434,19 +451,27 @@ class Roles(dict):
         bot (:class:`telegram.Bot`): A bot associated with this instance.
     """
 
-    def __init__(self, bot):
+    def __init__(self, bot: Bot) -> None:
         super().__init__()
+        self.__lock = Lock()
+        self.__roles: Dict[str, Role] = {}
         self.bot = bot
-        self.ADMINS = Role(name='admins')
-        self.CHAT_ADMINS = ChatAdminsRole(bot=self.bot)
-        self.CHAT_CREATOR = ChatCreatorRole(bot=self.bot)
 
-    def set_bot(self, bot):
+        self.admins = Role(name='admins')
+        self.chat_admins = ChatAdminsRole(bot=self.bot)
+        self.chat_creator = ChatCreatorRole(bot=self.bot)
+
+        self.chat_admins._set_custom_admin(self.admins)
+        self.chat_creator._set_custom_admin(self.admins)
+
+    def set_bot(self, bot: Bot) -> None:
         """If for some reason you can't pass the bot on initialization, you can set it with this
-        method. Make sure to set the bot before the first call of :attr:`CHAT_ADMINS` or
-        :attr:`CHAT_CREATOR`.
+        method. Make sure to set the bot before the first call of :attr:`chat_admins` or
+        :attr:`chat_creator`.
+
         Args:
             bot (:class:`telegram.Bot`): The bot to set.
+
         Raises:
             ValueError
         """
@@ -454,186 +479,100 @@ class Roles(dict):
             raise ValueError('Bot is already set for this Roles instance')
         self.bot = bot
 
-    def __delitem__(self, key):
-        """"""  # Remove method from docs
-        raise NotImplementedError('Please use remove_role.')
+    def __getitem__(self, item: str) -> Role:
+        with self.__lock:
+            return self.__roles[item]
 
-    def __setitem__(self, key, value):
-        """"""  # Remove method from docs
-        raise ValueError('Roles are immutable!')
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__roles)
 
-    def setitem(self, key, value):
-        super(Roles, self).__setitem__(key, value)
+    def __len__(self) -> int:
+        with self.__lock:
+            return len(self.__roles)
 
-    def setdefault(self, key, value=None):
-        """"""  # Remove method from docs
-        raise ValueError('Roles are immutable!')
-
-    def update(self, other):
-        """"""  # Remove method from docs
-        raise ValueError('Roles are immutable!')
-
-    def pop(self, key, default=None):
-        """"""  # Remove method from docs
-        raise NotImplementedError('Please use remove_role.')
-
-    def _pop(self, key, default=None):
-        return super(Roles, self).pop(key, default)
-
-    def popitem(self, key):
-        """"""  # Remove method from docs
-        raise NotImplementedError('Please use remove_role.')
-
-    def clear(self):
-        """"""  # Remove method from docs
-        raise NotImplementedError('Please use remove_role.')
-
-    def copy(self):
-        """"""  # Remove method from docs
-        raise NotImplementedError
-
-    def add_admin(self, chat_id):
-        """Adds a user/chat to the :attr:`ADMINS` role. Will do nothing if user/chat is already
+    def add_admin(self, chat_id: Union[int, List[int], Tuple[int, ...]]) -> None:
+        """Adds a user/chat to the :attr:`admins` role. Will do nothing if user/chat is already
         present.
 
         Args:
             chat_id (:obj:`int`): The users id
         """
-        self.ADMINS.add_member(chat_id)
+        self.admins.add_member(chat_id)
 
-    def kick_admin(self, chat_id):
-        """Kicks a user/chat from the :attr:`ADMINS` role. Will do nothing if user/chat is not
+    def kick_admin(self, chat_id: Union[int, List[int], Tuple[int, ...]]) -> None:
+        """Kicks a user/chat from the :attr:`admins` role. Will do nothing if user/chat is not
         present.
+
         Args:
             chat_id (:obj:`int`): The users/chats id
         """
-        self.ADMINS.kick_member(chat_id)
+        self.admins.kick_member(chat_id)
 
-    def add_role(self, name, chat_ids=None, parent_roles=None, child_roles=None):
-        """Creates and registers a new role. :attr:`ADMINS` will automatically be added to the
+    def add_role(
+        self,
+        name: str,
+        chat_ids: Union[int, List[int], Tuple[int, ...]] = None,
+        child_roles: Union['Role', List['Role'], Tuple['Role', ...]] = None,
+    ) -> None:
+        """Creates and registers a new role. :attr:`admins` will automatically be added to the
         roles parent roles, i.e. admins can do everything. The role can be accessed by it's
         name.
+
         Args:
             name (:obj:`str`, optional): A name for this role.
             chat_ids (:obj:`int` | iterable(:obj:`int`), optional): The ids of the users/chats of
                 this role.
-            parent_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`), optional):
-                Parent roles of this role.
             child_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`), optional):
                 Child roles of this role.
+
         Raises:
             ValueError
         """
         if name in self:
             raise ValueError('Role name is already taken.')
-        role = Role(
-            chat_ids=chat_ids, parent_roles=parent_roles, child_roles=child_roles, name=name
-        )
-        self.setitem(name, role)
-        role.add_parent_role(self.ADMINS)
+        role = Role(chat_ids=chat_ids, child_roles=child_roles, name=name)
+        role._set_custom_admin(self.admins)  # pylint: disable=W0212
+        with self.__lock:
+            self.__roles[name] = role
 
-    def remove_role(self, name):
+    def remove_role(self, name: str) -> Role:
         """Removes a role.
+
         Args:
             name (:obj:`str`): The name of the role to be removed
-        """
-        role = self._pop(name, None)
-        role.remove_parent_role(self.ADMINS)
 
-    def __eq__(self, other):
+        Returns:
+            The removed role.
+        """
+        with self.__lock:
+            role = self.__roles.pop(name)
+        self.admins.remove_child_role(role)
+        return role
+
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Roles):
             for name, role in self.items():
-                orole = other.get(name, None)
-                if not orole:
+                other_role = other.get(name, None)
+                if not other_role:
                     return False
-                if not role.equals(orole):
+                if not role.equals(other_role):
                     return False
-            if any([self.get(name, None) is None for name in other]):
+            if any(self.get(name, None) is None for name in other):
                 return False
-            return self.ADMINS.equals(other.ADMINS)
+            return self.admins.equals(other.admins)
         return False
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: Dict[int, Any]) -> 'Roles':
         new_roles = Roles(self.bot)
-        new_roles.CHAT_ADMINS.timeout = self.CHAT_ADMINS.timeout
+        new_roles.chat_admins.timeout = self.chat_admins.timeout
         memo[id(self)] = new_roles
-        for chat_id in self.ADMINS.chat_ids:
+        for chat_id in self.admins.chat_ids:
             new_roles.add_admin(chat_id)
         for role in self.values():
             new_roles.add_role(name=role.name, chat_ids=role.chat_ids)
-            for pr in role.parent_roles:
-                if pr is not self.ADMINS:
-                    new_roles[role.name].add_parent_role(deepcopy(pr, memo))
-            for cr in role.child_roles:
-                new_roles[role.name].add_child_role(deepcopy(cr, memo))
+            for child_role in role.child_roles:
+                new_roles[role.name].add_child_role(deepcopy(child_role, memo))
         return new_roles
-
-    def encode_to_json(self):
-        """Helper method to encode a roles object to a JSON-serializable way. Use
-        :attr:`decode_from_json` to decode.
-        Args:
-            roles (:class:`telegram.ext.Roles`): The roles object to transofrm to JSON.
-        Returns:
-            :obj:`str`: The JSON-serialized roles object
-        """
-
-        def _encode_role_to_json(role, memo, trace):
-            id_ = id(role)
-            if id_ not in memo and id_ not in trace:
-                trace.append(id_)
-                inner_tmp = {'name': role.name, 'chat_ids': sorted(role.chat_ids)}
-                inner_tmp['parent_roles'] = [
-                    _encode_role_to_json(pr, memo, trace) for pr in role.parent_roles
-                ]
-                inner_tmp['child_roles'] = [
-                    _encode_role_to_json(cr, memo, trace) for cr in role.child_roles
-                ]
-                memo[id_] = inner_tmp
-            return id_
-
-        tmp = {
-            'admins': id(self.ADMINS),
-            'admins_timeout': self.CHAT_ADMINS.timeout,
-            'roles': [],
-            'memo': {},
-        }
-        tmp['roles'] = [_encode_role_to_json(self[name], tmp['memo'], []) for name in self]
-        return json.dumps(tmp)
-
-    @staticmethod
-    def decode_from_json(json_string, bot):
-        """Helper method to decode a roles object to a JSON-string created with
-        :attr:`encode_roles_to_json`.
-        Args:
-            json_string (:obj:`str`): The roles object as JSON string.
-            bot (:class:`telegram.Bot`): The bot to be passed to the roles object.
-        Returns:
-            :class:`telegram.ext.Roles`: The roles object after decoding
-        """
-
-        def _decode_role_from_json(id_, memo):
-            id_ = str(id_)
-            if isinstance(memo[id_], Role):
-                return memo[id_]
-
-            tmp = memo[id_]
-            role = Role(name=tmp['name'], chat_ids=tmp['chat_ids'])
-            memo[id_] = role
-            for pid in tmp['parent_roles']:
-                role.add_parent_role(_decode_role_from_json(pid, memo))
-            for cid in tmp['child_roles']:
-                role.add_child_role(_decode_role_from_json(cid, memo))
-            return role
-
-        tmp = json.loads(json_string)
-        memo = tmp['memo']
-        roles = Roles(bot)
-        roles.ADMINS = _decode_role_from_json(tmp['admins'], memo)
-        roles.CHAT_ADMINS.timeout = tmp['admins_timeout']
-        for id_ in tmp['roles']:
-            role = _decode_role_from_json(id_, memo)
-            roles.setitem(role.name, role)
-        return roles

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -56,8 +56,9 @@ class Role(UpdateFilter, Filters.chat):
     similarly for ``role_2 <= role_3``.
 
     Note:
-        If two roles are not related, i.e. neither is a (indirect) parent of the other, comparing
-        the roles will always yield ``False``.
+        * If two roles are not related, i.e. neither is a (indirect) parent of the other, comparing
+         the roles will always yield ``False``.
+        * Updates that have neither effective chat nor effective user will not be allowed.
 
     Warning:
         ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact if

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -27,7 +27,6 @@ from typing import (
     Set,
     Tuple,
     FrozenSet,
-    Optional,
     Dict,
     Iterator,
     NoReturn,
@@ -194,7 +193,7 @@ class Role(UpdateFilter, Filters.chat):
         update: Update,
         target: 'Role' = None,
         inverted: bool = False,
-    ) -> Optional[bool]:
+    ) -> bool:
         # Always allow admins
         if self is not self._admin and self._admin.filter(update):
             return True
@@ -414,12 +413,10 @@ class ChatAdminsRole(Role):  # pylint: disable=R0901
     def __invert__(self) -> NoReturn:
         raise RuntimeError('Instances of ChatAdminsRole can not be inverted')
 
-    def filter(
-        self, update: Update, target: Role = None, inverted: bool = False
-    ) -> Optional[bool]:
+    def filter(self, update: Update, target: Role = None, inverted: bool = False) -> bool:
         # Always allow admins
         if self is not self._admin and self._admin.filter(update):
-            return not inverted
+            return True
 
         user = update.effective_user
         chat = update.effective_chat
@@ -463,10 +460,10 @@ class ChatCreatorRole(Role):  # pylint: disable=R0901
 
     def filter(  # pylint: disable=R0911
         self, update: Update, target: Role = None, inverted: bool = False
-    ) -> Optional[bool]:
+    ) -> bool:
         # Always allow admins
         if self is not self._admin and self._admin.filter(update):
-            return not inverted
+            return True
 
         user = update.effective_user
         chat = update.effective_chat

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains the class Role, which allows to restrict access to handlers."""
+import time
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+from copy import deepcopy
+
+from telegram import ChatMember, TelegramError, Bot, Chat
+from telegram.ext import Filters
+
+
+class Role(Filters.chat):
+    """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
+    hierarchy, i.e. a role can do everthing, its child roles can do. To compare two roles you may
+    use the following syntax::
+
+        role_1 < role_2
+        role 2 >= role_3
+
+    ``role_1 < role_2`` will be true, if ``role_2`` is a parent of ``role_1`` or a parent of one
+    of ``role_1`` s parents and similarly for ``role_1 < role_2``.
+    ``role_2 >= role_3`` will be true, if ``role_3`` is ``role_2`` or ``role_2 > role_3`` and
+    similarly for ``role_2 <= role_3``.
+
+    Note:
+        If two roles are not related, i.e. neither is a (indirect) parent of the other, comparing
+        the roles will always yield ``False``.
+
+    Warning:
+        ``role_1 == role_2`` does not test for the hierarchical order of the roles, but in fact if
+        both roles are the same object. To test for equality in terms of hierarchical order, i.e.
+        if :attr:`child_roles` and :attr:`chat_ids` coincide, use :attr:`equals`.
+
+    Roles can be combined using bitwise operators:
+
+    And:
+
+        >>> (Roles(name='group_1') & Roles(name='user_2'))
+
+    Grants access only for ``user_2`` within the chat ``group_1``.
+
+    Or:
+
+        >>> (Roles(name='group_1') | Roles(name='user_2'))
+
+    Grants access for ``user_2`` and the whole chat ``group_1``.
+
+    Not:
+
+        >>> ~ Roles(name='user_1')
+
+    Grants access to everyone except ``user_1``
+
+    Note:
+        Negated roles do `not` exclude their parent roles. E.g. with
+
+            >>> ~ Roles(name='user_1', parent_roles=Role(name='user_2'))
+
+        ``user_2`` will still have access, where ``user_1`` is restricted. Child roles, however
+        will be excluded.
+
+    Also works with more than two roles:
+
+        >>> (Roles(name='group_1') & (Roles(name='user_2') | Roles(name='user_3')))
+        >>> Roles(name='group_1') & (~ FRoles(name='user_2'))
+
+    Note:
+        Roles use the same short circuiting logic that pythons `and`, `or` and `not`.
+        This means that for example:
+
+            >>> Role(chat_ids=123) | Role(chat_ids=456)
+
+        With an update from user ``123``, will only ever evaluate the first role.
+
+    Warning:
+        :attr:`chat_ids` will give a *copy* of the saved chat ids as :class:`frozenset`. This
+        is to ensure thread safety. To add/remove a chat, you should use :meth:`add_chat_ids` and
+        :meth:`remove_chat_ids`. Only update the entire set by ``filter.chat_ids = new_set``, if
+        you are entirely sure that it is not causing race conditions, as this will complete replace
+        the current set of allowed chats.
+
+    Attributes:
+        chat_ids (set(:obj:`int`)): The ids of the users/chats of this role. Updates
+            will only be parsed, if the id of :attr:`telegram.Update.effective_user` or
+            :attr:`telegram.Update.effective_chat` respectiveley is listed here. May be empty.
+        parent_roles (set(:class:`telegram.ext.Role`)): Parent roles of this role. All the parent
+            roles can do anything, this role can do. May be empty.
+        child_roles (set(:class:`telegram.ext.Role`)): Child roles of this role. This role can do
+            anything, its child roles can do. May be empty.
+
+    Args:
+        chat_ids (:obj:`int` | iterable(:obj:`int`), optional): The ids of the users/chats of this
+            role. Updates will only be parsed, if the id of :attr:`telegram.Update.effective_user`
+            or :attr:`telegram.Update.effective_chat` respectiveley is listed here.
+        parent_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`)), optional):
+            Parent roles of this role.
+        child_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`)), optional):
+            Child roles of this role.
+        name (:obj:`str`, optional): A name for this role.
+    """
+
+    update_filter = True
+
+    def __init__(self, chat_ids=None, parent_roles=None, child_roles=None, name=None):
+        if chat_ids is None:
+            chat_ids = []
+        super().__init__(chat_ids)
+        self.name = name
+
+        self.parent_roles = set()
+        if isinstance(parent_roles, Role):
+            self.add_parent_role(parent_roles)
+        elif parent_roles is not None:
+            for pr in parent_roles:
+                self.add_parent_role(pr)
+
+        self.child_roles = set()
+        if isinstance(child_roles, Role):
+            self.add_child_role(child_roles)
+        elif child_roles is not None:
+            for cr in child_roles:
+                self.add_child_role(cr)
+
+        self._inverted = False
+
+    def __invert__(self):
+        self._inverted = True
+        return ~self
+
+    def filter_children(self, user, chat):
+        # filters only downward
+        if user and user.id in self.chat_ids:
+            return True
+        if chat and chat.id in self.chat_ids:
+            return True
+        if any([child.filter_children(user, chat) for child in self.child_roles]):
+            return True
+
+    def filter(self, update):
+        user = update.effective_user
+        chat = update.effective_chat
+        if user and user.id in self.chat_ids:
+            return True
+        if chat and chat.id in self.chat_ids:
+            return True
+        if user or chat:
+            if self._inverted:
+                # If this is an inverted role (i.e. ~role) and we arrived here, the user is
+                # either ...
+                if self.filter_children(user, chat):
+                    # ... in a child role of this. In this case, and must be excluded. Since the
+                    # output of this will be negated, return True
+                    return True
+                # ... not in a child role of this and must *nto* be excluded. In particular, we
+                # dont want to exclude the parents (see below). Since the output of this will be
+                # negated, return False
+                return False
+            else:
+                return any([parent(update) for parent in self.parent_roles])
+
+    def add_member(self, chat_id):
+        """Adds a user/chat to this role. Will do nothing, if user/chat is already present.
+
+        Args:
+            chat_id (:obj:`int`): The users/chats id
+        """
+        self.add_chat_ids(chat_id)
+
+    def kick_member(self, chat_id):
+        """Kicks a user/chat to from role. Will do nothing, if user/chat is not present.
+
+        Args:
+            chat_id (:obj:`int`): The users/chats id
+        """
+        self.remove_chat_ids(chat_id)
+
+    def add_parent_role(self, parent_role):
+        """Adds a parent role to this role. Also adds this role to the parents child roles. Will do
+        nothing, if parent role is already present.
+
+        Args:
+            parent_role (:class:`telegram.ext.Role`): The parent role
+        """
+        if self is parent_role:
+            raise ValueError('You must not add a role as its own parent!')
+        if self >= parent_role:
+            raise ValueError('You must not add a child role as a parent!')
+        self.parent_roles.add(parent_role)
+        parent_role.child_roles.add(self)
+
+    def remove_parent_role(self, parent_role):
+        """Removes a parent role from this role. Also removes this role from the parents child
+        roles. Will do nothing, if parent role is not present.
+
+        Args:
+            parent_role (:class:`telegram.ext.Role`): The parent role
+        """
+        self.parent_roles.discard(parent_role)
+        parent_role.child_roles.discard(self)
+
+    def add_child_role(self, child_role):
+        """Adds a child role to this role. Also adds this role to the childs parent roles. Will do
+        nothing, if child role is already present.
+
+        Args:
+            child_role (:class:`telegram.ext.Role`): The child role
+        """
+        if self is child_role:
+            raise ValueError('You must not add a role as its own child!')
+        if self <= child_role:
+            raise ValueError('You must not add a parent role as a child!')
+        self.child_roles.add(child_role)
+        child_role.parent_roles.add(self)
+
+    def remove_child_role(self, child_role):
+        """Removes a child role from this role. Also removes this role from the childs parent
+        roles. Will do nothing, if child role is not present.
+
+        Args:
+            child_role (:class:`telegram.ext.Role`): The child role
+        """
+        self.child_roles.discard(child_role)
+        child_role.parent_roles.discard(self)
+
+    def __lt__(self, other):
+        # Test for hierarchical order
+        if isinstance(other, Role):
+            return any([pr <= other for pr in self.parent_roles])
+        return False
+
+    def __le__(self, other):
+        # Test for hierarchical order
+        return self is other or self < other
+
+    def __gt__(self, other):
+        # Test for hierarchical order
+        if isinstance(other, Role):
+            return any([self >= pr for pr in other.parent_roles])
+        return False
+
+    def __ge__(self, other):
+        # Test for hierarchical order
+        return self is other or self > other
+
+    def __eq__(self, other):
+        return self is other
+
+    def __ne__(self, other):
+        return not self == other
+
+    def equals(self, other):
+        """Test if two roles are equal in terms of hierarchy. Returns :obj:``True``, if the
+        :attr:`chat_ids` coincide and the child roles are equal in terms of this method. Note, that
+        the result of this comparison may change by adding or removing child/parent roles or
+        members.
+
+        Args:
+            other (:class:`telegram.ext.Role`):
+
+        Returns:
+            :obj:`bool`:
+        """
+        if self.chat_ids == other.chat_ids:
+            if len(self.child_roles) == len(other.child_roles):
+                if len(self.child_roles) == 0:
+                    return True
+                for cr in self.child_roles:
+                    if not any([cr.equals(ocr) for ocr in other.child_roles]):
+                        return False
+                for ocr in other.child_roles:
+                    if not any([ocr.equals(cr) for cr in self.child_roles]):
+                        return False
+                return True
+        return False
+
+    def __hash__(self):
+        return id(self)
+
+    def __deepcopy__(self, memo):
+        new_role = Role(chat_ids=self.chat_ids, name=self.name)
+        memo[id(self)] = new_role
+        for pr in self.parent_roles:
+            new_role.add_parent_role(deepcopy(pr, memo))
+        for cr in self.child_roles:
+            new_role.add_child_role(deepcopy(cr, memo))
+        return new_role
+
+    def __repr__(self):
+        if self.name:
+            return f'Role({self.name})'
+        elif self.chat_ids:
+            return f'Role({self.chat_ids})'
+        else:
+            return 'Role({})'
+
+
+class ChatAdminsRole(Role):
+    """A :class:`telegram.ext.Role` that allows only the administrators of a chat. Private chats
+    are always allowed. To minimize the number of API calls, for each chat the admins will be
+    cached.
+
+    Attributes:
+        timeout (:obj:`int`): The caching timeout in seconds. For each chat, the admins will be
+            cached and refreshed only after this timeout.
+
+    Args:
+        bot (:class:`telegram.Bot`): A bot to use for getting the administrators of a chat.
+        timeout (:obj:`int`, optional): The caching timeout in seconds. For each chat, the admins
+            will be cached and refreshed only after this timeout. Defaults to ``1800`` (half an
+            hour).
+    """
+
+    def __init__(self, bot, timeout=1800):
+        super().__init__(name='chat_admins')
+        self.bot = bot
+        self.cache = {}
+        self.timeout = timeout
+
+    def filter(self, update):
+        user = update.effective_user
+        chat = update.effective_chat
+
+        if user and chat:
+            # Always true in private chats
+            if chat.type == Chat.PRIVATE:
+                return True
+
+            # Check for cached info first
+            if (
+                self.cache.get(chat.id, None)
+                and (time.time() - self.cache[chat.id][0]) < self.timeout
+            ):
+                return user.id in self.cache[chat.id][1]
+
+            admins = [m.user.id for m in self.bot.get_chat_administrators(chat.id)]
+            self.cache[chat.id] = (time.time(), admins)
+            return user.id in admins
+
+    def __deepcopy__(self, memo):
+        new_role = super().__deepcopy__(memo)
+        new_role.bot = self.bot
+        new_role.cache = self.cache
+        new_role.timeout = self.timeout
+        return new_role
+
+
+class ChatCreatorRole(Role):
+    """A :class:`telegram.ext.Role` that allows only the creator of a chat. Private chats are
+    always allowed. To minimize the number of API calls, for each chat the creator will be saved.
+
+    Args:
+        bot (:class:`telegram.Bot`): A bot to use for getting the creator of a chat.
+    """
+
+    def __init__(self, bot):
+        super().__init__(name='chat_creator')
+        self.bot = bot
+        self.cache = {}
+
+    def filter(self, update):
+        user = update.effective_user
+        chat = update.effective_chat
+
+        if user and chat:
+            # Always true in private chats
+            if chat.type == Chat.PRIVATE:
+                return True
+
+            # Check for cached info first
+            if self.cache.get(chat.id, None):
+                return user.id == self.cache[chat.id]
+            try:
+                member = self.bot.get_chat_member(chat.id, user.id)
+                if member.status == ChatMember.CREATOR:
+                    self.cache[chat.id] = user.id
+                    return True
+                return False
+            except TelegramError:
+                # user is not a chat member or bot has no access
+                return False
+
+    def __deepcopy__(self, memo):
+        new_role = super(ChatCreatorRole, self).__deepcopy__(memo)
+        new_role.bot = self.bot
+        new_role.cache = self.cache
+        return new_role
+
+
+class Roles(dict):
+    """This class represents a collection of :class:`telegram.ext.Role` s that can be used to
+    manage access control to functionality of a bot. Each role can be accessed by its name, e.g.::
+            roles.add_role('my_role')
+            role = roles['my_role']
+
+    Note:
+        In fact, :class:`telegram.ext.Roles` inherits from :obj:`dict` and thus provides most
+        methods needed for the common use cases. Methods that are *not* supported are:
+        ``__delitem__``, ``__setitem__``, ``setdefault``, ``update``, ``pop``, ``popitem``,
+        ``clear`` and ``copy``.
+        Please use :attr:`add_role` and :attr:`remove_role` instead.
+
+    Attributes:
+        ADMINS (:class:`telegram.ext.Role`): A role reserved for administrators of the bot. All
+            roles added to this instance will be child roles of :attr:`ADMINS`.
+        CHAT_ADMINS (:class:`telegram.ext.roles.ChatAdminsRole`): Use this role to restrict access
+            to admins of a chat. Handlers with this role wont handle updates that don't have an
+            ``effective_chat``. Admins are cached for each chat.
+        CHAT_CREATOR (:class:`telegram.ext.roles.ChatCreatorRole`): Use this role to restrict
+            access to the creator of a chat. Handlers with this role wont handle updates that don't
+            have an ``effective_chat``.
+
+    Args:
+        bot (:class:`telegram.Bot`): A bot associated with this instance.
+    """
+
+    def __init__(self, bot):
+        super().__init__()
+        self.bot = bot
+        self.ADMINS = Role(name='admins')
+        self.CHAT_ADMINS = ChatAdminsRole(bot=self.bot)
+        self.CHAT_CREATOR = ChatCreatorRole(bot=self.bot)
+
+    def set_bot(self, bot):
+        """If for some reason you can't pass the bot on initialization, you can set it with this
+        method. Make sure to set the bot before the first call of :attr:`CHAT_ADMINS` or
+        :attr:`CHAT_CREATOR`.
+        Args:
+            bot (:class:`telegram.Bot`): The bot to set.
+        Raises:
+            ValueError
+        """
+        if isinstance(self.bot, Bot):
+            raise ValueError('Bot is already set for this Roles instance')
+        self.bot = bot
+
+    def __delitem__(self, key):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def __setitem__(self, key, value):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def setitem(self, key, value):
+        super(Roles, self).__setitem__(key, value)
+
+    def setdefault(self, key, value=None):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def update(self, other):
+        """"""  # Remove method from docs
+        raise ValueError('Roles are immutable!')
+
+    def pop(self, key, default=None):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def _pop(self, key, default=None):
+        return super(Roles, self).pop(key, default)
+
+    def popitem(self, key):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def clear(self):
+        """"""  # Remove method from docs
+        raise NotImplementedError('Please use remove_role.')
+
+    def copy(self):
+        """"""  # Remove method from docs
+        raise NotImplementedError
+
+    def add_admin(self, chat_id):
+        """Adds a user/chat to the :attr:`ADMINS` role. Will do nothing if user/chat is already
+        present.
+
+        Args:
+            chat_id (:obj:`int`): The users id
+        """
+        self.ADMINS.add_member(chat_id)
+
+    def kick_admin(self, chat_id):
+        """Kicks a user/chat from the :attr:`ADMINS` role. Will do nothing if user/chat is not
+        present.
+        Args:
+            chat_id (:obj:`int`): The users/chats id
+        """
+        self.ADMINS.kick_member(chat_id)
+
+    def add_role(self, name, chat_ids=None, parent_roles=None, child_roles=None):
+        """Creates and registers a new role. :attr:`ADMINS` will automatically be added to the
+        roles parent roles, i.e. admins can do everything. The role can be accessed by it's
+        name.
+        Args:
+            name (:obj:`str`, optional): A name for this role.
+            chat_ids (:obj:`int` | iterable(:obj:`int`), optional): The ids of the users/chats of
+                this role.
+            parent_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`), optional):
+                Parent roles of this role.
+            child_roles (:class:`telegram.ext.Role` | set(:class:`telegram.ext.Role`), optional):
+                Child roles of this role.
+        Raises:
+            ValueError
+        """
+        if name in self:
+            raise ValueError('Role name is already taken.')
+        role = Role(
+            chat_ids=chat_ids, parent_roles=parent_roles, child_roles=child_roles, name=name
+        )
+        self.setitem(name, role)
+        role.add_parent_role(self.ADMINS)
+
+    def remove_role(self, name):
+        """Removes a role.
+        Args:
+            name (:obj:`str`): The name of the role to be removed
+        """
+        role = self._pop(name, None)
+        role.remove_parent_role(self.ADMINS)
+
+    def __eq__(self, other):
+        if isinstance(other, Roles):
+            for name, role in self.items():
+                orole = other.get(name, None)
+                if not orole:
+                    return False
+                if not role.equals(orole):
+                    return False
+            if any([self.get(name, None) is None for name in other]):
+                return False
+            return self.ADMINS.equals(other.ADMINS)
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __deepcopy__(self, memo):
+        new_roles = Roles(self.bot)
+        new_roles.CHAT_ADMINS.timeout = self.CHAT_ADMINS.timeout
+        memo[id(self)] = new_roles
+        for chat_id in self.ADMINS.chat_ids:
+            new_roles.add_admin(chat_id)
+        for role in self.values():
+            new_roles.add_role(name=role.name, chat_ids=role.chat_ids)
+            for pr in role.parent_roles:
+                if pr is not self.ADMINS:
+                    new_roles[role.name].add_parent_role(deepcopy(pr, memo))
+            for cr in role.child_roles:
+                new_roles[role.name].add_child_role(deepcopy(cr, memo))
+        return new_roles
+
+    def encode_to_json(self):
+        """Helper method to encode a roles object to a JSON-serializable way. Use
+        :attr:`decode_from_json` to decode.
+        Args:
+            roles (:class:`telegram.ext.Roles`): The roles object to transofrm to JSON.
+        Returns:
+            :obj:`str`: The JSON-serialized roles object
+        """
+
+        def _encode_role_to_json(role, memo, trace):
+            id_ = id(role)
+            if id_ not in memo and id_ not in trace:
+                trace.append(id_)
+                inner_tmp = {'name': role.name, 'chat_ids': sorted(role.chat_ids)}
+                inner_tmp['parent_roles'] = [
+                    _encode_role_to_json(pr, memo, trace) for pr in role.parent_roles
+                ]
+                inner_tmp['child_roles'] = [
+                    _encode_role_to_json(cr, memo, trace) for cr in role.child_roles
+                ]
+                memo[id_] = inner_tmp
+            return id_
+
+        tmp = {
+            'admins': id(self.ADMINS),
+            'admins_timeout': self.CHAT_ADMINS.timeout,
+            'roles': [],
+            'memo': {},
+        }
+        tmp['roles'] = [_encode_role_to_json(self[name], tmp['memo'], []) for name in self]
+        return json.dumps(tmp)
+
+    @staticmethod
+    def decode_from_json(json_string, bot):
+        """Helper method to decode a roles object to a JSON-string created with
+        :attr:`encode_roles_to_json`.
+        Args:
+            json_string (:obj:`str`): The roles object as JSON string.
+            bot (:class:`telegram.Bot`): The bot to be passed to the roles object.
+        Returns:
+            :class:`telegram.ext.Roles`: The roles object after decoding
+        """
+
+        def _decode_role_from_json(id_, memo):
+            id_ = str(id_)
+            if isinstance(memo[id_], Role):
+                return memo[id_]
+
+            tmp = memo[id_]
+            role = Role(name=tmp['name'], chat_ids=tmp['chat_ids'])
+            memo[id_] = role
+            for pid in tmp['parent_roles']:
+                role.add_parent_role(_decode_role_from_json(pid, memo))
+            for cid in tmp['child_roles']:
+                role.add_child_role(_decode_role_from_json(cid, memo))
+            return role
+
+        tmp = json.loads(json_string)
+        memo = tmp['memo']
+        roles = Roles(bot)
+        roles.ADMINS = _decode_role_from_json(tmp['admins'], memo)
+        roles.CHAT_ADMINS.timeout = tmp['admins_timeout']
+        for id_ in tmp['roles']:
+            role = _decode_role_from_json(id_, memo)
+            roles.setitem(role.name, role)
+        return roles

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -334,7 +334,7 @@ class Role(UpdateFilter, Filters.chat):
         return id(self)
 
     @property
-    def name(self) -> str:
+    def name(self) -> str:  # pylint: disable=C0116
         if self._name:
             return f'Role({self._name})'
         if self.chat_ids:

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains the RoleHandler class."""
+from typing import Any
+
+from telegram import Update
+from telegram.ext import Handler, CallbackContext, Dispatcher
+
+from .roles import Role, Roles
+
+BOT_DATA_KEY: str = 'ptbcontrib_roles_bot_data_key'
+""":obj:`str`: The key used to store roles in ``bot_data``."""
+
+
+def setup_roles(dispatcher: Dispatcher) -> Roles:
+    """
+    Retrieves the :class:`ptbcontrib.roles.Roles` instance stored in :attr:`dispatcher.bot_data`
+    or creates a new one and saves it under :attr:`BOT_DATA_KEY`.
+
+    Args:
+        dispatcher (:class:`telegram.ext.Dispatcher`): The dispatcher
+
+    Returns:
+        The :class:`ptbcontrib.roles.Roles` instance to be used.
+    """
+    if BOT_DATA_KEY not in dispatcher.bot_data:
+        dispatcher.bot_data[BOT_DATA_KEY] = Roles(dispatcher.bot)
+    return dispatcher.bot_data[BOT_DATA_KEY]
+
+
+class RolesHandler(Handler):
+    """
+    A handler that acts as wrapper for existing handler classes allowing to add roles for
+    user access management. You must call :meth:`setup_roles` before this handler can work.
+    The :class:`ptbcontrib.roles.Roles` instance will then be available as ``context.roles`` in the
+    callback.
+
+    Note:
+        As :class:`ptbcontrib.roles.Roles` does not allow updates that have neither effective user
+        nor effective chat, this handler wrapper should not be used in combination with handlers
+        that handle such updates, e.g. :class:`telegram.ext.StringCommandHandler`.
+
+    Args:
+        handler (:class:`telegram.ext.Handler`): The handler to wrap.
+        roles (:class:`ptbcontrib.roles.Roles`): The roles to apply to the handler. Can be combined
+            with bitwise operations.
+    """
+
+    def __init__(self, handler: Handler, roles: Role) -> None:
+        self.handler = handler
+        self.roles: Role = roles
+        super().__init__(self._callback)
+
+    def _callback(self, update: Update, context: CallbackContext) -> Any:
+        return self.handler.callback(update, context)
+
+    def check_update(self, update: Update) -> bool:
+        if self.roles(update):
+            return self.handler.check_update(update)
+        return False
+
+    def collect_additional_context(
+        self,
+        context: CallbackContext,
+        update: Update,
+        dispatcher: Dispatcher,
+        check_result: Any,
+    ) -> None:
+        self.handler.collect_additional_context(context, update, dispatcher, check_result)
+        if BOT_DATA_KEY not in context.bot_data:
+            raise RuntimeError('You must set a Roles instance before you can use RolesHandlers.')
+        context.roles = context.bot_data[BOT_DATA_KEY]

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains the RoleHandler class."""
+"""This module contains the RolesHandler class."""
 from typing import Any
 
 from telegram import Update
@@ -39,9 +39,7 @@ def setup_roles(dispatcher: Dispatcher) -> Roles:
     Returns:
         The :class:`ptbcontrib.roles.Roles` instance to be used.
     """
-    if BOT_DATA_KEY not in dispatcher.bot_data:
-        dispatcher.bot_data[BOT_DATA_KEY] = Roles(dispatcher.bot)
-    return dispatcher.bot_data[BOT_DATA_KEY]
+    return dispatcher.bot_data.setdefault(BOT_DATA_KEY, Roles(dispatcher.bot))
 
 
 class RolesHandler(Handler):
@@ -65,10 +63,7 @@ class RolesHandler(Handler):
     def __init__(self, handler: Handler, roles: Role) -> None:
         self.handler = handler
         self.roles: Role = roles
-        super().__init__(self._callback)
-
-    def _callback(self, update: Update, context: CallbackContext) -> Any:
-        return self.handler.callback(update, context)
+        super().__init__(self.handler.callback)
 
     def check_update(self, update: Update) -> bool:
         if self.roles(update):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,15 +40,15 @@ TOKEN = '1281106207:AAHXR4nqP-ZYsPLnrHooton3zUGGnsoNjZ8'
 
 
 @pytest.fixture(scope='session')
-def bot(bot_info):
-    return make_bot(bot_info)
+def bot():
+    return make_bot()
 
 
 DEFAULT_BOTS = {}
 
 
 @pytest.fixture(scope='function')
-def default_bot(request, bot_info):
+def default_bot(request):
     param = request.param if hasattr(request, 'param') else {}
 
     defaults = Defaults(**param)
@@ -56,19 +56,19 @@ def default_bot(request, bot_info):
     if default_bot:
         return default_bot
     else:
-        default_bot = make_bot(bot_info, **{'defaults': defaults})
+        default_bot = make_bot(**{'defaults': defaults})
         DEFAULT_BOTS[defaults] = default_bot
         return default_bot
 
 
 @pytest.fixture(scope='function')
-def tz_bot(timezone, bot_info):
+def tz_bot(timezone):
     defaults = Defaults(tzinfo=timezone)
     default_bot = DEFAULT_BOTS.get(defaults)
     if default_bot:
         return default_bot
     else:
-        default_bot = make_bot(bot_info, **{'defaults': defaults})
+        default_bot = make_bot(**{'defaults': defaults})
         DEFAULT_BOTS[defaults] = default_bot
         return default_bot
 
@@ -131,7 +131,7 @@ def pytest_configure(config):
     # TODO: Write so good code that we don't need to ignore ResourceWarnings anymore
 
 
-def make_bot(bot_info, **kwargs):
+def make_bot(**kwargs):
     return Bot(TOKEN, private_key=PRIVATE_KEY, **kwargs)
 
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime
+
+import pytest
+import sys
+import time
+
+from copy import deepcopy
+from telegram import Message, User, InlineQuery, Update, ChatMember, Chat, TelegramError
+from telegram.ext import (
+    Role,
+    Roles,
+    MessageHandler,
+    InlineQueryHandler,
+    ChatAdminsRole,
+    ChatCreatorRole,
+)
+
+
+@pytest.fixture(scope='function')
+def update():
+    return Update(
+        0, Message(0, User(0, 'Testuser', False), datetime.datetime.utcnow(), Chat(0, 'private'))
+    )
+
+
+@pytest.fixture(scope='function')
+def roles(bot):
+    return Roles(bot)
+
+
+@pytest.fixture(scope='function')
+def parent_role():
+    return Role(name='parent_role')
+
+
+@pytest.fixture(scope='function')
+def role():
+    return Role(name='role')
+
+
+@pytest.fixture(scope='function')
+def chat_admins_role(bot):
+    return ChatAdminsRole(bot, 0.05)
+
+
+@pytest.fixture(scope='function')
+def chat_creator_role(bot):
+    return ChatCreatorRole(bot)
+
+
+class TestRole(object):
+    def test_creation(self, parent_role):
+        r = Role(parent_roles=[parent_role, parent_role])
+        assert r.chat_ids == set()
+        assert str(r) == 'Role({})'
+        assert r.parent_roles == set([parent_role])
+
+        r = Role(child_roles=[parent_role, parent_role])
+        assert r.chat_ids == set()
+        assert str(r) == 'Role({})'
+        assert r.child_roles == set([parent_role])
+
+        parent_role_2 = Role(name='parent_role_2')
+        r = Role(parent_roles=[parent_role, parent_role_2])
+        assert r.chat_ids == set()
+        assert str(r) == 'Role({})'
+        assert r.parent_roles == set([parent_role, parent_role_2])
+
+        r = Role(1)
+        assert r.chat_ids == set([1])
+        assert str(r) == 'Role({1})'
+        assert r.parent_roles == set()
+
+        r = Role([1, 2])
+        assert r.chat_ids == set([1, 2])
+        assert str(r) == 'Role({1, 2})'
+        assert r.parent_roles == set()
+
+        r = Role([1, 2], name='role')
+        assert r.chat_ids == set([1, 2])
+        assert str(r) == 'Role(role)'
+        assert r.parent_roles == set()
+
+    def test_chat_ids_property(self, role):
+        assert role.chat_ids is role.user_ids
+        role.chat_ids = 5
+        assert role.chat_ids == set([5])
+
+    def test_add_member(self, role):
+        assert role.chat_ids == set()
+        role.add_member(1)
+        assert role.chat_ids == set([1])
+        role.add_member(2)
+        assert role.chat_ids == set([1, 2])
+        role.add_member(1)
+        assert role.chat_ids == set([1, 2])
+
+    def test_kick_member(self, role):
+        assert role.chat_ids == set()
+        role.add_member(1)
+        role.add_member(2)
+        assert role.chat_ids == set([1, 2])
+        role.kick_member(1)
+        assert role.chat_ids == set([2])
+        role.kick_member(1)
+        assert role.chat_ids == set([2])
+        role.kick_member(2)
+        assert role.chat_ids == set()
+
+    def test_add_remove_parent_role(self, role, parent_role):
+        assert role.parent_roles == set()
+        parent_role_2 = Role(chat_ids=456, name='pr2')
+        role.add_parent_role(parent_role)
+        assert role.parent_roles == set([parent_role])
+        role.add_parent_role(parent_role_2)
+        assert role.parent_roles == set([parent_role, parent_role_2])
+
+        role.remove_parent_role(parent_role)
+        assert role.parent_roles == set([parent_role_2])
+        role.remove_parent_role(parent_role_2)
+        assert role.parent_roles == set()
+
+        with pytest.raises(ValueError, match='You must not add a role as its own parent!'):
+            role.add_parent_role(role)
+
+        parent_role.add_parent_role(role)
+        with pytest.raises(ValueError, match='You must not add a child role as a parent!'):
+            role.add_parent_role(parent_role)
+
+    def test_add_remove_child_role(self, role, parent_role):
+        assert role.child_roles == set()
+        parent_role_2 = Role(chat_ids=456, name='pr2')
+        role.add_child_role(parent_role)
+        assert role.child_roles == set([parent_role])
+        role.add_child_role(parent_role_2)
+        assert role.child_roles == set([parent_role, parent_role_2])
+
+        role.remove_child_role(parent_role)
+        assert role.child_roles == set([parent_role_2])
+        role.remove_child_role(parent_role_2)
+        assert role.child_roles == set()
+
+        with pytest.raises(ValueError, match='You must not add a role as its own child!'):
+            role.add_child_role(role)
+
+        parent_role.add_child_role(role)
+        with pytest.raises(ValueError, match='You must not add a parent role as a child!'):
+            role.add_child_role(parent_role)
+
+    def test_equals(self, role, parent_role):
+        r = Role(name='test1')
+        r2 = Role(name='test2')
+        r3 = Role(name='test3', chat_ids=[1, 2])
+        r4 = Role(name='test4')
+        assert role.equals(parent_role)
+        role.add_child_role(r)
+        assert not role.equals(parent_role)
+        parent_role.add_child_role(r2)
+        assert role.equals(parent_role)
+        parent_role.add_child_role(r3)
+        role.add_child_role(r4)
+        assert not role.equals(parent_role)
+        role.remove_child_role(r4)
+        parent_role.remove_child_role(r3)
+
+        role.add_member(1)
+        assert not role.equals(parent_role)
+        parent_role.add_member(1)
+        assert role.equals(parent_role)
+        role.add_member(2)
+        assert not role.equals(parent_role)
+        parent_role.add_member(2)
+        assert role.equals(parent_role)
+        role.kick_member(2)
+        assert not role.equals(parent_role)
+        parent_role.kick_member(2)
+        assert role.equals(parent_role)
+
+        r.add_member(1)
+        assert not role.equals(parent_role)
+        r2.add_member(1)
+        assert role.equals(parent_role)
+
+    def test_comparison(self, role, parent_role):
+        assert not role <= 1
+        assert not role >= 1
+
+        assert not role < parent_role
+        assert not parent_role < role
+        assert role <= role
+        assert role >= role
+        assert parent_role <= parent_role
+        assert parent_role >= parent_role
+
+        role.add_parent_role(parent_role)
+        assert role < parent_role
+        assert role <= parent_role
+        assert parent_role >= role
+        assert parent_role > role
+
+        role.remove_parent_role(parent_role)
+        assert not role < parent_role
+        assert not parent_role < role
+
+        role.add_parent_role(parent_role)
+        assert role < parent_role
+        assert role <= parent_role
+        assert parent_role >= role
+        assert parent_role > role
+
+    def test_hash(self, role, parent_role):
+        assert role != parent_role
+        assert hash(role) != hash(parent_role)
+
+        assert role == role
+        assert hash(role) == hash(role)
+
+        assert parent_role == parent_role
+        assert hash(parent_role) == hash(parent_role)
+
+    def test_deepcopy(self, role, parent_role):
+        role.add_parent_role(parent_role)
+        child = Role(name='cr', chat_ids=[1, 2, 3], parent_roles=role)
+        crole = deepcopy(role)
+
+        assert role is not crole
+        assert role.equals(crole)
+        assert role.chat_ids is not crole.chat_ids
+        assert role.chat_ids == crole.chat_ids
+        assert role.parent_roles is not crole.parent_roles
+        parent = role.parent_roles.pop()
+        cparent = crole.parent_roles.pop()
+        assert parent is not cparent
+        assert parent.equals(cparent)
+        cchild = crole.child_roles.pop()
+        assert child is not cchild
+        assert child.equals(cchild)
+
+    def test_handler_user(self, update, role, parent_role):
+        handler = MessageHandler(role, None)
+        assert not handler.check_update(update)
+
+        role.add_member(0)
+        parent_role.add_member(1)
+
+        assert handler.check_update(update)
+        update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert not handler.check_update(update)
+        role.add_parent_role(parent_role)
+        assert handler.check_update(update)
+
+    def test_handler_chat(self, update, role, parent_role):
+        handler = MessageHandler(role, None)
+        update.message.chat.id = 5
+        assert not handler.check_update(update)
+
+        role.add_member(5)
+        parent_role.add_member(6)
+
+        assert handler.check_update(update)
+        update.message.chat.id = 6
+        assert not handler.check_update(update)
+        role.add_parent_role(parent_role)
+        assert handler.check_update(update)
+
+    def test_handler_merged_roles(self, update, role):
+        role.add_member(0)
+        r = Role(0)
+
+        handler = MessageHandler(None, None, roles=role & (~r))
+        assert not handler.check_update(update)
+
+        r = Role(1)
+        handler = MessageHandler(None, None, roles=role & r)
+        assert not handler.check_update(update)
+        handler = MessageHandler(None, None, roles=role | r)
+        assert handler.check_update(update)
+
+    def test_handler_allow_parent(self, update, role, parent_role):
+        role.add_member(0)
+        parent_role.add_member(1)
+        role.add_parent_role(parent_role)
+
+        handler = MessageHandler(None, None, roles=~role)
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert handler.check_update(update)
+
+    def test_handler_exclude_children(self, update, role, parent_role):
+        role.add_parent_role(parent_role)
+        parent_role.add_member(0)
+        role.add_member(1)
+
+        handler = MessageHandler(None, None, roles=~parent_role)
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert not handler.check_update(update)
+        update.message.from_user.id = 2
+        update.message.chat.id = 1
+        assert not handler.check_update(update)
+
+    def test_handler_without_user(self, update, role):
+        handler = MessageHandler(role, None)
+        role.add_member(0)
+        update.message = None
+        update.channel_post = Message(0, None, datetime.datetime.utcnow(), Chat(-1, 'channel'))
+        assert not handler.check_update(update)
+
+        role.add_member(-1)
+        assert handler.check_update(update)
+
+
+class TestChatAdminsRole(object):
+    def test_creation(self, bot):
+        admins = ChatAdminsRole(bot, timeout=7)
+        assert admins.timeout == 7
+        assert admins.bot is bot
+
+    def test_deepcopy(self, chat_admins_role):
+        chat_admins_role.cache.update({1: 2, 3: 4})
+        cadmins = deepcopy(chat_admins_role)
+
+        assert chat_admins_role is not cadmins
+        assert chat_admins_role.equals(cadmins)
+        assert chat_admins_role.chat_ids is not cadmins.chat_ids
+        assert chat_admins_role.chat_ids == cadmins.chat_ids
+        assert chat_admins_role.parent_roles is not cadmins.parent_roles
+        assert chat_admins_role.child_roles is not cadmins.child_roles
+
+        assert chat_admins_role.bot is cadmins.bot
+        assert chat_admins_role.cache == cadmins.cache
+        assert chat_admins_role.timeout == cadmins.timeout
+
+    def test_simple(self, chat_admins_role, update, monkeypatch):
+        def admins(*args, **kwargs):
+            return [
+                ChatMember(User(0, 'TestUser0', False), 'administrator'),
+                ChatMember(User(1, 'TestUser1', False), 'creator'),
+            ]
+
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
+        handler = MessageHandler(None, None, roles=chat_admins_role)
+
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        update.message.from_user.id = 0
+        assert handler.check_update(update)
+
+    def test_private_chat(self, chat_admins_role, update):
+        update.message.from_user.id = 2
+        update.message.chat.id = 2
+        handler = MessageHandler(None, None, roles=chat_admins_role)
+
+        assert handler.check_update(update)
+
+    def test_no_chat(self, chat_admins_role, update):
+        update.message = None
+        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
+        handler = InlineQueryHandler(None, roles=chat_admins_role)
+
+        assert not handler.check_update(update)
+
+    def test_no_user(self, chat_admins_role, update):
+        update.message = None
+        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        handler = InlineQueryHandler(None, roles=chat_admins_role)
+
+        assert not handler.check_update(update)
+
+    def test_caching(self, chat_admins_role, update, monkeypatch):
+        def admins(*args, **kwargs):
+            return [
+                ChatMember(User(0, 'TestUser0', False), 'administrator'),
+                ChatMember(User(1, 'TestUser1', False), 'creator'),
+            ]
+
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
+        handler = MessageHandler(None, None, roles=chat_admins_role)
+
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+        assert isinstance(chat_admins_role.cache[0], tuple)
+        assert pytest.approx(chat_admins_role.cache[0][0]) == time.time()
+        assert chat_admins_role.cache[0][1] == [0, 1]
+
+        def admins(*args, **kwargs):
+            raise ValueError('This method should not be called!')
+
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
+
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+
+        time.sleep(0.05)
+
+        def admins(*args, **kwargs):
+            return [ChatMember(User(2, 'TestUser0', False), 'administrator')]
+
+        monkeypatch.setattr(chat_admins_role.bot, 'get_chat_administrators', admins)
+
+        update.message.from_user.id = 2
+        assert handler.check_update(update)
+        assert isinstance(chat_admins_role.cache[0], tuple)
+        assert pytest.approx(chat_admins_role.cache[0][0]) == time.time()
+        assert chat_admins_role.cache[0][1] == [2]
+
+
+class TestChatCreatorRole(object):
+    def test_creation(self, bot):
+        creator = ChatCreatorRole(bot)
+        assert creator.bot is bot
+
+    def test_deepcopy(self, chat_creator_role):
+        chat_creator_role.cache.update({1: 2, 3: 4})
+        ccreator = deepcopy(chat_creator_role)
+
+        assert chat_creator_role is not ccreator
+        assert chat_creator_role.equals(ccreator)
+        assert chat_creator_role.chat_ids is not ccreator.chat_ids
+        assert chat_creator_role.chat_ids == ccreator.chat_ids
+        assert chat_creator_role.parent_roles is not ccreator.parent_roles
+        assert chat_creator_role.child_roles is not ccreator.child_roles
+
+        assert chat_creator_role.bot is ccreator.bot
+        assert chat_creator_role.cache == ccreator.cache
+
+    def test_simple(self, chat_creator_role, monkeypatch, update):
+        def member(*args, **kwargs):
+            if args[1] == 0:
+                return ChatMember(User(0, 'TestUser0', False), 'administrator')
+            if args[1] == 1:
+                return ChatMember(User(1, 'TestUser1', False), 'creator')
+            raise TelegramError('User is not a member')
+
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
+        handler = MessageHandler(None, None, roles=chat_creator_role)
+
+        update.message.from_user.id = 0
+        update.message.chat.id = -1
+        assert not handler.check_update(update)
+        update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert handler.check_update(update)
+        update.message.from_user.id = 2
+        update.message.chat.id = -2
+        assert not handler.check_update(update)
+
+    def test_no_chat(self, chat_creator_role, update):
+        update.message = None
+        update.inline_query = InlineQuery(1, User(0, 'TestUser', False), 'query', 0)
+        handler = InlineQueryHandler(None, roles=chat_creator_role)
+
+        assert not handler.check_update(update)
+
+    def test_no_user(self, chat_creator_role, update):
+        update.message = None
+        update.channel_post = Message(1, None, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        handler = InlineQueryHandler(None, roles=chat_creator_role)
+
+        assert not handler.check_update(update)
+
+    def test_private_chat(self, chat_creator_role, update):
+        update.message.from_user.id = 2
+        update.message.chat.id = 2
+        handler = MessageHandler(None, None, roles=chat_creator_role)
+
+        assert handler.check_update(update)
+
+    def test_caching(self, chat_creator_role, monkeypatch, update):
+        def member(*args, **kwargs):
+            if args[1] == 0:
+                return ChatMember(User(0, 'TestUser0', False), 'administrator')
+            if args[1] == 1:
+                return ChatMember(User(1, 'TestUser1', False), 'creator')
+            raise TelegramError('User is not a member')
+
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
+        handler = MessageHandler(None, None, roles=chat_creator_role)
+
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+        assert chat_creator_role.cache == {0: 1}
+
+        def member(*args, **kwargs):
+            raise ValueError('This method should not be called!')
+
+        monkeypatch.setattr(chat_creator_role.bot, 'get_chat_member', member)
+
+        update.message.from_user.id = 1
+        assert handler.check_update(update)
+
+        update.message.from_user.id = 2
+        assert not handler.check_update(update)
+
+
+class TestRoles(object):
+    def test_creation(self, bot):
+        roles = Roles(bot)
+        assert isinstance(roles, dict)
+        assert isinstance(roles.ADMINS, Role)
+        assert isinstance(roles.CHAT_ADMINS, Role)
+        assert roles.CHAT_ADMINS.bot is bot
+        assert isinstance(roles.CHAT_CREATOR, Role)
+        assert roles.CHAT_CREATOR.bot is bot
+        assert roles.bot is bot
+
+    def test_set_bot(self, bot):
+        roles = Roles(1)
+        assert roles.bot == 1
+        roles.set_bot(2)
+        assert roles.bot == 2
+        roles.set_bot(bot)
+        assert roles.bot is bot
+        with pytest.raises(ValueError, match='already set'):
+            roles.set_bot(bot)
+
+    def test_add_kick_admin(self, roles):
+        assert roles.ADMINS.chat_ids == set()
+        roles.add_admin(1)
+        assert roles.ADMINS.chat_ids == set([1])
+        roles.add_admin(2)
+        assert roles.ADMINS.chat_ids == set([1, 2])
+        roles.kick_admin(1)
+        assert roles.ADMINS.chat_ids == set([2])
+        roles.kick_admin(2)
+        assert roles.ADMINS.chat_ids == set()
+
+    def test_equality(self, parent_role, roles, bot):
+        parent_role_2 = deepcopy(parent_role)
+        child_role = Role(name='child_role')
+        child_role_2 = deepcopy(child_role)
+
+        roles2 = Roles(bot)
+        assert roles == roles2
+
+        roles.add_admin(1)
+        assert roles != roles2
+
+        roles2.add_admin(1)
+        assert roles == roles2
+
+        roles.add_role('test_role', chat_ids=123)
+        assert roles != roles2
+
+        roles2.add_role('test_role', chat_ids=123)
+        assert roles == roles2
+
+        roles.add_role('test_role_2', chat_ids=456)
+        assert roles != roles2
+
+        roles2.add_role('test_role_2', chat_ids=456)
+        assert roles == roles2
+
+        roles['test_role'].add_parent_role(parent_role)
+        roles2['test_role'].add_parent_role(parent_role_2)
+        assert roles == roles2
+
+        roles['test_role'].add_child_role(child_role)
+        assert roles != roles2
+
+        roles2['test_role'].add_child_role(child_role_2)
+        assert roles == roles2
+
+    def test_raise_errors(self, roles):
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            del roles['test']
+        with pytest.raises(ValueError, match='immutable'):
+            roles['test'] = True
+        with pytest.raises(ValueError, match='immutable'):
+            roles.setdefault('test', None)
+        with pytest.raises(ValueError, match='immutable'):
+            roles.update({'test': None})
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.pop('test', None)
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.popitem('test')
+        with pytest.raises(NotImplementedError, match='remove_role'):
+            roles.clear()
+        with pytest.raises(NotImplementedError):
+            roles.copy()
+
+    @pytest.mark.skipif(sys.version_info < (3, 6), reason="dicts are not ordered in py<=3.5")
+    def test_dict_functionality(self, roles):
+        roles.add_role('role0', 0)
+        roles.add_role('role1', 1)
+        roles.add_role('role2', 2)
+
+        assert 'role2' in roles
+        assert 'role3' not in roles
+
+        a = set([name for name in roles])
+        assert a == set(['role{}'.format(k) for k in range(3)])
+
+        b = {name: role.chat_ids for name, role in roles.items()}
+        assert b == {'role{}'.format(k): set([k]) for k in range(3)}
+
+        c = [name for name in roles.keys()]
+        assert c == ['role{}'.format(k) for k in range(3)]
+
+        d = [r.chat_ids for r in roles.values()]
+        assert d == [set([k]) for k in range(3)]
+
+    def test_deepcopy(self, roles, parent_role):
+        roles.add_admin(123)
+        roles.CHAT_ADMINS.timeout = 7
+        child_role = Role(name='child_role')
+        roles.add_role(
+            name='test', chat_ids=[1, 2], parent_roles=parent_role, child_roles=child_role
+        )
+        roles.add_role(name='test2', chat_ids=[3, 4], child_roles=roles['test'])
+        croles = deepcopy(roles)
+
+        assert croles is not roles
+        assert croles == roles
+        assert roles.ADMINS is not croles.ADMINS
+        assert roles.ADMINS.equals(croles.ADMINS)
+        assert roles.CHAT_ADMINS.timeout == croles.CHAT_ADMINS.timeout
+        assert roles['test'] is not croles['test']
+        assert roles['test'].equals(croles['test'])
+        assert roles['test2'] is not croles['test2']
+        assert roles['test2'].equals(croles['test2'])
+
+    def test_add_remove_role(self, roles, parent_role):
+        roles.add_role('role', parent_roles=parent_role)
+        role = roles['role']
+        assert role.chat_ids == set()
+        assert role.parent_roles == set([parent_role, roles.ADMINS])
+        assert str(role) == 'Role(role)'
+        assert roles.ADMINS in role.parent_roles
+
+        with pytest.raises(ValueError, match='Role name is already taken.'):
+            roles.add_role('role', parent_roles=parent_role)
+
+        roles.remove_role('role')
+        assert not roles.get('role', None)
+        assert roles.ADMINS not in role.parent_roles
+
+    def test_handler_admins(self, roles, update):
+        roles.add_role('role', 0)
+        roles.add_admin(1)
+        handler = MessageHandler(None, None, roles=roles['role'])
+        assert handler.check_update(update)
+        update.message.from_user.id = 1
+        update.message.chat.id = 1
+        assert handler.check_update(update)
+        roles.kick_admin(1)
+        assert not handler.check_update(update)
+
+    def test_handler_admins_merged(self, roles, update):
+        roles.add_role('role_1', 0)
+        roles.add_role('role_2', 1)
+        roles.add_admin(2)
+        handler = MessageHandler(None, None, roles=roles['role_1'] & ~roles['role_2'])
+        assert handler.check_update(update)
+        update.message.from_user.id = 2
+        update.message.chat.id = 2
+        assert handler.check_update(update)
+        roles.kick_admin(2)
+        assert not handler.check_update(update)
+
+    def test_json_encoding_decoding(self, roles, parent_role, bot):
+        child_role = Role(name='child_role')
+        roles.add_role('role_1', chat_ids=[1, 2, 3])
+        roles.add_role(
+            'role_2', chat_ids=[4, 5, 6], parent_roles=parent_role, child_roles=child_role
+        )
+        roles.add_role('role_3', chat_ids=[7, 8], parent_roles=parent_role, child_roles=child_role)
+        roles.add_admin(9)
+        roles.add_admin(10)
+        roles.CHAT_ADMINS.timeout = 7
+
+        json_str = roles.encode_to_json()
+        assert isinstance(json_str, str)
+        assert json_str != ''
+
+        rroles = Roles.decode_from_json(json_str, bot)
+        assert rroles == roles
+        assert rroles.bot is bot
+        for name in rroles:
+            assert rroles[name] <= rroles.ADMINS
+        assert rroles.ADMINS.chat_ids == set([9, 10])
+        assert rroles.ADMINS.equals(roles.ADMINS)
+        assert rroles.CHAT_ADMINS.timeout == roles.CHAT_ADMINS.timeout
+        assert rroles['role_1'].chat_ids == set([1, 2, 3])
+        assert rroles['role_1'].equals(Role(name='role_1', chat_ids=[1, 2, 3]))
+        assert rroles['role_2'].chat_ids == set([4, 5, 6])
+        assert rroles['role_2'].equals(
+            Role(
+                name='role_2', chat_ids=[4, 5, 6], parent_roles=parent_role, child_roles=child_role
+            )
+        )
+        assert rroles['role_3'].chat_ids == set([7, 8])
+        assert rroles['role_3'].equals(
+            Role(name='role_3', chat_ids=[7, 8], parent_roles=parent_role, child_roles=child_role)
+        )
+        for name in rroles:
+            assert rroles[name] <= rroles.ADMINS
+            assert rroles[name] < rroles.ADMINS
+            assert rroles.ADMINS >= rroles[name]
+            assert rroles.ADMINS > rroles[name]

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-import datetime
+import datetime as dtm
 import os
 import pickle
 import subprocess
@@ -52,7 +52,7 @@ def update():
     return Update(
         0,
         Message(
-            0, datetime.datetime.utcnow(), Chat(0, 'private'), from_user=User(0, 'TestUser', False)
+            0, dtm.datetime.utcnow(), Chat(0, 'private'), from_user=User(0, 'TestUser', False)
         ),
     )
 
@@ -330,6 +330,7 @@ class TestRole:
         role.add_member(0)
         update.message = None
         assert not role(update)
+        assert not (~role)(update)
 
     def test_always_allow_admin(self, update, role):
         role._admin.add_member(0)
@@ -414,7 +415,7 @@ class TestChatAdminsRole:
 
     def test_no_user(self, chat_admins_role, update):
         update.message = None
-        update.channel_post = Message(1, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        update.channel_post = Message(1, dtm.datetime.utcnow(), Chat(0, 'channel'))
 
         assert not chat_admins_role(update)
 
@@ -511,7 +512,7 @@ class TestChatCreatorRole:
 
     def test_no_user(self, chat_creator_role, update):
         update.message = None
-        update.channel_post = Message(1, datetime.datetime.utcnow(), Chat(0, 'channel'))
+        update.channel_post = Message(1, dtm.datetime.utcnow(), Chat(0, 'channel'))
 
         assert not chat_creator_role(update)
 


### PR DESCRIPTION
Reworking of [ptb/#1789](https://github.com/python-telegram-bot/python-telegram-bot/pull/1789) for ptbcontrib.

Currently will fail, as the persistence setup needs [ptb/#2212](https://github.com/python-telegram-bot/python-telegram-bot/issues/2212) to be fixed (hence marking as WIP)

On the fly edits some stuff in `conftest.py` allowing to actually run the tests. Overlooked that on the initial repo setup b/c `extract_urls` doesn't use `dispatcher/bot`