### PR TITLE
Add a send_by_kwargs method

### DIFF
--- a/ptbcontrib/send_by_kwargs/README.md
+++ b/ptbcontrib/send_by_kwargs/README.md
@@ -1,11 +1,11 @@
 # `send_by_kwargs`
 
-Provides a methods that allows to send any kind of message by just providing a dictionary of keyword arguments.
+Provides a function that allows to send any kind of message by just providing a dictionary of keyword arguments.
 
 *   Tries to auto-detect the appropriate `send_*` method
 *   If the call to selected `send_*` method fails, gives a helpful error message
 
-**Note:** Due to `send_dice` currently being the only method that only has `chat_id` as required parameter, this will *always* be chosen if `chat_id` is present in the keywords arguments but no other method fits. 
+**Note:** If `chat_id` is present in the keywords arguments but no other method fits, `send_dice` will *always* be chosen. This is due to `send_dice` currently being the only method that only has `chat_id` as required parameter.
 
 Usage:
 

--- a/ptbcontrib/send_by_kwargs/README.md
+++ b/ptbcontrib/send_by_kwargs/README.md
@@ -5,7 +5,7 @@ Provides a function that allows to send any kind of message by just providing a 
 *   Tries to auto-detect the appropriate `send_*` method
 *   If the call to selected `send_*` method fails, gives a helpful error message
 
-**Note:** If `chat_id` is present in the keywords arguments but no other method fits, `send_dice` will *always* be chosen. This is due to `send_dice` currently being the only method that only has `chat_id` as required parameter.
+**Note:** If `chat_id` is present in the keywords arguments but no other method fits, `send_dice` will *always* be chosen. This is due to `send_dice` currently being the only method that has solely `chat_id` as a required parameter.
 
 Usage:
 

--- a/ptbcontrib/send_by_kwargs/README.md
+++ b/ptbcontrib/send_by_kwargs/README.md
@@ -2,8 +2,8 @@
 
 Provides a methods that allows to send any kind of message by just providing a dictionary of keyword arguments.
 
-* Tries to auto-detect the appropriate `send_*` method
-* If the call to selected `send_*` method fails, gives a helpful error message
+*   Tries to auto-detect the appropriate `send_*` method
+*   If the call to selected `send_*` method fails, gives a helpful error message
 
 **Note:** Due to `send_dice` currently being the only method that only has `chat_id` as required parameter, this will *always* be chosen if `chat_id` is present in the keywords arguments but no other method fits. 
 

--- a/ptbcontrib/send_by_kwargs/README.md
+++ b/ptbcontrib/send_by_kwargs/README.md
@@ -1,0 +1,31 @@
+# `send_by_kwargs`
+
+Provides a methods that allows to send any kind of message by just providing a dictionary of keyword arguments.
+
+* Tries to auto-detect the appropriate `send_*` method
+* If the call to selected `send_*` method fails, gives a helpful error message
+
+**Note:** Due to `send_dice` currently being the only method that only has `chat_id` as required parameter, this will *always* be chosen if `chat_id` is present in the keywords arguments but no other method fits. 
+
+Usage:
+
+```python
+from ptbcontrib.send_by_kwargs import send_by_kwargs
+    
+# Sends using send_message
+send_by_kwargs(bot, {'text': 'Hello there!'}, chat_id=123})
+    
+# Sends using send_photo
+with open('photo.jpg', 'rb') as file:
+    send_by_kwargs(bot, {'photo': file, 'chat_id' : 123})
+```
+
+Please see the docstrings for more details.
+
+## Requirements
+
+*   `python-telegram-bot>=12.0`
+
+## Authors
+
+*   [Hinrich Mahler](https://github.com/bibo-joshi)

--- a/ptbcontrib/send_by_kwargs/README.md
+++ b/ptbcontrib/send_by_kwargs/README.md
@@ -12,12 +12,14 @@ Usage:
 ```python
 from ptbcontrib.send_by_kwargs import send_by_kwargs
     
+kwargs = {'text': 'Hello there', 'caption': 'General Kenobi'}
+
 # Sends using send_message
-send_by_kwargs(bot, {'text': 'Hello there!'}, chat_id=123})
+send_by_kwargs(bot, kwargs, chat_id=123)
     
-# Sends using send_photo
+# Sends using send_photo with a caption and ignores the text kwarg
 with open('photo.jpg', 'rb') as file:
-    send_by_kwargs(bot, {'photo': file, 'chat_id' : 123})
+    send_by_kwargs(bot, kwargs, photo=file, chat_id=123)
 ```
 
 Please see the docstrings for more details.

--- a/ptbcontrib/send_by_kwargs/__init__.py
+++ b/ptbcontrib/send_by_kwargs/__init__.py
@@ -1,0 +1,21 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2021
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains helper functions to extract URLs from messages."""
+
+from .send_by_kwargs import send_by_kwargs
+
+__all__ = ['send_by_kwargs']

--- a/ptbcontrib/send_by_kwargs/__init__.py
+++ b/ptbcontrib/send_by_kwargs/__init__.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains helper functions to extract URLs from messages."""
+"""This module contains a helper function that allows to send any kind of message by kwargs."""
 
 from .send_by_kwargs import send_by_kwargs
 

--- a/ptbcontrib/send_by_kwargs/requirements.txt
+++ b/ptbcontrib/send_by_kwargs/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=12.0

--- a/ptbcontrib/send_by_kwargs/send_by_kwargs.py
+++ b/ptbcontrib/send_by_kwargs/send_by_kwargs.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2021
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains helper functions to extract URLs from messages."""
+import inspect
+from collections import OrderedDict
+from typing import List, Dict, Union, Callable
+
+from telegram import Message, Bot
+
+UNIQUE_KWARGS = OrderedDict(
+    {
+        'send_animation': ['animation'],
+        'send_audio': ['audio'],
+        'send_chat_action': ['action'],
+        'send_contact': ['phone_number', 'contact'],
+        'send_document': ['document'],
+        'send_game': ['game_short_name'],
+        'send_invoice': ['prices'],
+        # venue must be before location as location has all args of venue, but not vice versa
+        'send_venue': ['address', 'venue'],
+        'send_location': ['latitude', 'location'],
+        'send_media_group': ['media'],
+        'send_message': ['text'],
+        'send_photo': ['photo'],
+        'send_poll': ['question'],
+        'send_sticker': ['sticker'],
+        'send_video': ['video'],
+        'send_video_note': ['video_note'],
+        'send_voice': ['voice'],
+        # Important to test last, as this only requires chat_id
+        'send_dice': ['chat_id'],
+    }
+)
+
+CACHED_SIGNATURES: Dict[str, inspect.Signature] = {}
+
+
+class MissingRequiredParam(Exception):
+    """Auxiliary Exception class for internal usage."""
+
+    def __init__(self, param_name: str):
+        super().__init__()
+        self.param_name = param_name
+
+
+def get_relevant_kwargs(method: Callable, kwargs: Dict[str, object]) -> Dict[str, object]:
+    """
+    Extracts the kwargs relevant for the method at hand. For internal usage.
+    """
+    signature = CACHED_SIGNATURES.setdefault(method.__name__, inspect.signature(method))
+    relevant_kwargs = {}
+    for name, param in signature.parameters.items():
+        if param.default == inspect.Parameter.empty:
+            if name not in kwargs:
+                raise MissingRequiredParam(name)
+            relevant_kwargs[name] = kwargs[name]
+        # we don't just do kwargs.get(name, None) here to make sure
+        # that this still works with telegram.ext.Defaults
+        elif name in kwargs:
+            relevant_kwargs[name] = kwargs[name]
+    return relevant_kwargs
+
+
+def send_by_kwargs(
+    bot: Bot, kwargs: Dict[str, object] = None, **_kwargs: object
+) -> Union[Message, List[Message]]:
+    """
+    Convenience method for sending arbitrary messages by providing the corresponding keywords.
+    Auto-selects the corresponding bot method. For flexibility, arguments can be passed both by
+    passing a dict and by specifying them directly as keyword arguments::
+
+        send_by_kwargs(bot, kwargs={'text'='Hi'}, chat_id=123)
+
+    Note:
+        Keyword arguments passed directly will override those passed in the dictionary ``kwargs``.
+
+    Args:
+        bot (:class:`telegram.Bot`): The bot to send the message with.
+        kwargs (Dict[:obj:`str`, :obj:`object:], optional): The keyword arguments as dictionary.
+        **_kwargs (Dict[:obj:`str`, :obj:`object:], optional): Additional keyword arguments passed
+            as actual keyword arguments.
+
+    Returns:
+        :class:`telegram.Message` | List[:class:`telegram.Message`]:
+    """
+    if kwargs is None:
+        kwargs = {}
+    kwargs.update(_kwargs)
+
+    for method_name, unique_kwarg in UNIQUE_KWARGS.items():
+        if any(uk in kwargs for uk in unique_kwarg):
+            selected_method = method_name
+            break
+    else:
+        raise RuntimeError('Could not find a bot method to call for the passed kwargs.')
+
+    try:
+        method = getattr(bot, selected_method)
+        relevant_kwargs = get_relevant_kwargs(method, kwargs)
+    except MissingRequiredParam as exc:
+        raise KeyError(
+            f'Selected method {method.__name__}, but the required parameter '
+            f'{exc.param_name} is missing in the provided kwargs.'
+        ) from exc
+
+    try:
+        return method(**relevant_kwargs)
+    except Exception as exc:
+        raise RuntimeError(
+            f'Selected method {method.__name__}, but it raised the above exception.'
+        ) from exc

--- a/ptbcontrib/send_by_kwargs/send_by_kwargs.py
+++ b/ptbcontrib/send_by_kwargs/send_by_kwargs.py
@@ -90,8 +90,8 @@ def send_by_kwargs(
 
     Args:
         bot (:class:`telegram.Bot`): The bot to send the message with.
-        kwargs (Dict[:obj:`str`, :obj:`object:], optional): The keyword arguments as dictionary.
-        **_kwargs (Dict[:obj:`str`, :obj:`object:], optional): Additional keyword arguments passed
+        kwargs (Dict[:obj:`str`, :obj:`object`], optional): The keyword arguments as dictionary.
+        **_kwargs (Dict[:obj:`str`, :obj:`object`], optional): Additional keyword arguments passed
             as actual keyword arguments.
 
     Returns:

--- a/tests/test_send_by_kwargs.py
+++ b/tests/test_send_by_kwargs.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2021
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+import inspect
+import random
+import pytest
+from telegram import TelegramError
+
+from ptbcontrib.send_by_kwargs import send_by_kwargs
+from ptbcontrib.send_by_kwargs.send_by_kwargs import UNIQUE_KWARGS, CACHED_SIGNATURES
+
+temp = list(UNIQUE_KWARGS.items())
+random.shuffle(temp)
+UNIQUE_KWARGS_SHUFFLED = {key: value for key, value in temp}
+
+
+class TestSendByKwargs:
+    test_flag = False
+
+    @pytest.fixture(scope='function', autouse=True)
+    def reset(self):
+        self.test_flag = False
+
+    @pytest.mark.parametrize(
+        argnames='method,args',
+        argvalues=list(UNIQUE_KWARGS_SHUFFLED.items()),
+        ids=list(UNIQUE_KWARGS_SHUFFLED),
+    )
+    def test_correct_selection(self, method, args, bot):
+        if method == 'send_dice':
+            pytest.skip('send_dice only has one required parameter anyway')
+
+        kwargs = {args[0]: args[0]}
+
+        with pytest.raises(
+            KeyError, match=f'Selected method {method}, but the required parameter'
+        ):
+            send_by_kwargs(bot, kwargs)
+
+        with pytest.raises(
+            KeyError, match=f'Selected method {method}, but the required parameter'
+        ):
+            send_by_kwargs(bot, **kwargs)
+
+    @pytest.mark.parametrize(
+        argnames='method',
+        argvalues=list(UNIQUE_KWARGS_SHUFFLED),
+    )
+    def test_kwargs_passing(self, method, bot, monkeypatch):
+
+        signature = inspect.signature(getattr(bot, method))
+        expected_kwargs = {name: True for name, param in signature.parameters.items()}
+        kwargs = expected_kwargs.copy()
+        kwargs['dummy'] = 'this_should_not_be_passed'
+
+        def make_assertion(**_kwargs):
+            self.test_flag = _kwargs == expected_kwargs
+
+        # we're a bit tricky here, because otherwise monkeypatch would fiddle with the signature
+        CACHED_SIGNATURES['make_assertion'] = signature
+
+        monkeypatch.setattr(bot, method, make_assertion)
+        send_by_kwargs(bot, kwargs)
+        assert self.test_flag
+
+        self.test_flag = False
+        send_by_kwargs(bot, **kwargs)
+        assert self.test_flag
+
+    @pytest.mark.parametrize(
+        argnames='method',
+        argvalues=list(UNIQUE_KWARGS_SHUFFLED),
+    )
+    @pytest.mark.parametrize(
+        argnames='timeout', argvalues=[None, 5], ids=['default_timeout', 'custom_timeout']
+    )
+    def test_defaults_handling(self, method, timeout, bot, monkeypatch):
+        def make_assertion(**kwargs):
+            if timeout is None:
+                self.test_flag = 'timeout' not in kwargs
+            else:
+                self.test_flag = kwargs.get('timeout', None) == 5
+
+        signature = inspect.signature(getattr(bot, method))
+        kwargs = {
+            name: True
+            for name, param in signature.parameters.items()
+            if param.default == inspect.Parameter.empty
+            # special casing for some methods where the required arguments are not clear
+            # due to the fact that we made them optional in order to allow passing e.g. a Venue
+            # directly
+            or name in ['latitude', 'longitude', 'address', 'phone_number', 'first_name']
+        }
+        if timeout is not None:
+            kwargs['timeout'] = 5
+
+        # we're a bit tricky here, because otherwise monkeypatch would fiddle with the signature
+        CACHED_SIGNATURES['make_assertion'] = signature
+
+        monkeypatch.setattr(bot, method, make_assertion)
+        send_by_kwargs(bot, kwargs)
+        assert self.test_flag
+
+        self.test_flag = False
+        send_by_kwargs(bot, **kwargs)
+        assert self.test_flag
+
+    def test_fallback_behavior(self, monkeypatch, bot):
+        def make_assertion(**kwargs):
+            self.test_flag = True
+
+        signature = inspect.signature(bot.send_dice)
+        CACHED_SIGNATURES['make_assertion'] = signature
+        monkeypatch.setattr(bot, 'send_dice', make_assertion)
+        send_by_kwargs(bot, {'chat_id': 1})
+        assert self.test_flag
+
+        with pytest.raises(RuntimeError, match='Could not find a bot method'):
+            send_by_kwargs(bot, {})
+
+    @pytest.mark.parametrize(
+        'kwargs,_kwargs',
+        [
+            [{'chat_id': 123, 'text': 'Hello there'}, {}],
+            [{}, {'chat_id': 123, 'text': 'Hello there'}],
+            [{'chat_id': 123}, {'text': 'Hello there'}],
+            [
+                {'chat_id': 456, 'text': 'General Kenobi'},
+                {'chat_id': 123, 'text': 'Hello there'},
+            ],
+        ],
+    )
+    def test_kwarg_mixing(self, bot, monkeypatch, kwargs, _kwargs):
+        expected_kwargs = {'chat_id': 123, 'text': 'Hello there'}
+
+        def make_assertion(**kw):
+            self.test_flag = kw == expected_kwargs
+
+        signature = inspect.signature(bot.send_message)
+        CACHED_SIGNATURES['make_assertion'] = signature
+        monkeypatch.setattr(bot, 'send_message', make_assertion)
+        send_by_kwargs(bot, kwargs, **_kwargs)
+        assert self.test_flag
+
+    def test_method_raises_exception(self, bot, monkeypatch):
+        def mock(**kw):
+            raise TelegramError()
+
+        signature = inspect.signature(bot.send_message)
+        CACHED_SIGNATURES['mock'] = signature
+        monkeypatch.setattr(bot, 'send_message', mock)
+        with pytest.raises(RuntimeError, match='Selected method mock, but it raised'):
+            send_by_kwargs(bot, chat_id=123, text='Hi')

--- a/tests/test_send_by_kwargs.py
+++ b/tests/test_send_by_kwargs.py
@@ -48,12 +48,12 @@ class TestSendByKwargs:
         kwargs = {args[0]: args[0]}
 
         with pytest.raises(
-            KeyError, match=f'Selected method {method}, but the required parameter'
+            KeyError, match=f"Selected method '{method}', but the required parameter"
         ):
             send_by_kwargs(bot, kwargs)
 
         with pytest.raises(
-            KeyError, match=f'Selected method {method}, but the required parameter'
+            KeyError, match=f"Selected method '{method}', but the required parameter"
         ):
             send_by_kwargs(bot, **kwargs)
 
@@ -62,6 +62,10 @@ class TestSendByKwargs:
         argvalues=list(UNIQUE_KWARGS_SHUFFLED),
     )
     def test_kwargs_passing(self, method, bot, monkeypatch):
+        """
+        This essentially makes sure that get_relevant_kwargs doesn't pass kwargs that are not
+        accepted by the selected method.
+        """
 
         signature = inspect.signature(getattr(bot, method))
         expected_kwargs = {name: True for name, param in signature.parameters.items()}
@@ -158,11 +162,11 @@ class TestSendByKwargs:
         assert self.test_flag
 
     def test_method_raises_exception(self, bot, monkeypatch):
-        def mock(**kw):
+        def mock(**_kw):
             raise TelegramError()
 
         signature = inspect.signature(bot.send_message)
         CACHED_SIGNATURES['mock'] = signature
         monkeypatch.setattr(bot, 'send_message', mock)
-        with pytest.raises(RuntimeError, match='Selected method mock, but it raised'):
+        with pytest.raises(RuntimeError, match="Selected method 'mock', but it raised"):
             send_by_kwargs(bot, chat_id=123, text='Hi')


### PR DESCRIPTION
Common use cases include sending arbitrary stored media types and currently one has to manually select the correct method for that. This either includes a lot of `if`s or (as this PR does) `getattr(bot, method_name)`. Something like surely requires too much maintenance in PTB itself, but I figude it should be good enough for ptbcontrib.