### PR TITLE
Updater roles & tests

### DIFF
--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -145,7 +145,7 @@ class Role(UpdateFilter):
             self._admin.add_child_role(self)
 
     @staticmethod
-    def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int, ...]]) -> Set[int]:
+    def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int, ...], None]) -> Set[int]:
         if chat_id is None:
             return set()
         if isinstance(chat_id, int):

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -34,14 +34,12 @@ from typing import (
 )
 
 from telegram import ChatMember, TelegramError, Bot, Chat, Update
-from telegram.ext import Filters, UpdateFilter
+from telegram.ext import UpdateFilter
 
 _REPLACED_LOCK: str = 'ptbcontrib_roles_replaced_lock'
 
 
-# Order of the base classes matter, as Filters.chat is a MessageFilter, but we want to
-# misuse it as UpdateFilter
-class Role(UpdateFilter, Filters.chat):
+class Role(UpdateFilter):
     """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
     hierarchy, i.e. a role can do everthing, its child roles can do. To compare two roles you may
     use the following syntax::
@@ -132,11 +130,11 @@ class Role(UpdateFilter, Filters.chat):
         child_roles: Union['Role', List['Role'], Tuple['Role', ...]] = None,
         name: str = None,
     ) -> None:
-        super().__init__(chat_ids)
         self._name = name
         self._inverted = False
         self.__lock = Lock()
 
+        self._chat_ids = self._parse_chat_id(chat_ids)
         self._child_roles: Set['Role'] = set()
         self._set_child_roles(child_roles)
 
@@ -145,6 +143,14 @@ class Role(UpdateFilter, Filters.chat):
             self.__init_admin()
             self._admin_event.wait()
             self._admin.add_child_role(self)
+
+    @staticmethod
+    def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int, ...]]) -> Set[int]:
+        if chat_id is None:
+            return set()
+        if isinstance(chat_id, int):
+            return {chat_id}
+        return set(chat_id)
 
     @staticmethod
     def __init_admin() -> None:
@@ -173,6 +179,12 @@ class Role(UpdateFilter, Filters.chat):
     ) -> None:
         with self.__lock:
             self._child_roles = self._parse_child_role(child_role)
+
+    @property
+    def chat_ids(self) -> FrozenSet[int]:
+        """Chat IDs of this role as frozenset (to ensure thread safety)."""
+        with self.__lock:
+            return frozenset(self._chat_ids)
 
     @property
     def child_roles(self) -> FrozenSet['Role']:
@@ -241,7 +253,8 @@ class Role(UpdateFilter, Filters.chat):
             chat_id(:obj:`int` | List[:obj:`int`], optional): Which chat ID(s) to allow
                 through.
         """
-        self.add_chat_ids(chat_id)
+        with self.__lock:
+            self._chat_ids |= self._parse_chat_id(chat_id)
 
     def kick_member(self, chat_id: Union[int, List[int], Tuple[int, ...]]) -> None:
         """Kicks one ore more user(s)/chat(s) to from role. Will do nothing, if user/chat is not
@@ -250,7 +263,8 @@ class Role(UpdateFilter, Filters.chat):
         Args:
             chat_id(:obj:`int` | List[:obj:`int`], optional): The users/chats id
         """
-        self.remove_chat_ids(chat_id)
+        with self.__lock:
+            self._chat_ids -= self._parse_chat_id(chat_id)
 
     def add_child_role(self, child_role: 'Role') -> None:
         """Adds a child role to this role. Will do nothing, if child role is already present.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def create_dp(bot):
     # we mock bot.{get_me, get_my_commands} b/c those are used in the @info decorator
     def get_me(*args, **kwargs):
         user = User(1, 'TestBot', True)
-        dispatcher.bot.bot = user
+        dispatcher.bot._bot = user
         return user
 
     def get_my_commands(*args, **kwargs):
@@ -125,10 +125,12 @@ def dp(_dp):
     _dp.handlers = {}
     _dp.groups = []
     _dp.error_handlers = {}
-    _dp.__stop_event = Event()
-    _dp.__exception_event = Event()
-    _dp.__async_queue = Queue()
-    _dp.__async_threads = set()
+    # For some reason if we setattr with the name mangled, then some tests(like async) run forever,
+    # due to threads not acquiring, (blocking). This adds these attributes to the __dict__.
+    object.__setattr__(_dp, '__stop_event', Event())
+    object.__setattr__(_dp, '__exception_event', Event())
+    object.__setattr__(_dp, '__async_queue', Queue())
+    object.__setattr__(_dp, '__async_threads', set())
     _dp.persistence = None
     _dp.use_context = False
     if _dp._Dispatcher__singleton_semaphore.acquire(blocking=0):


### PR DESCRIPTION
* Makes roles subclass directly from `UpdateFilter` instead of `Filters.chat` - a bit more to manually implement here, but it's actually cleaner and doesn't fail the tests
* Also adapts tests to slots in ptb v13.6. also still works on v13.5, tested that manually