### PR TITLE
Update setup_roles for custom bot_data allowed via ContextTypes since PTB v13.6

### DIFF
--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -25,11 +25,11 @@ my_role_1.add_child_role(my_role_2)
 def add_to_my_role_2(update, context):
     user = update.effective_user
     # 'roles' is stored in context.bot_data[BOT_DATA_KEY]
-    context.bot_data[BOT_DATA_KEY]['my_role_2'].add_member(user.id)
+    context.roles['my_role_2'].add_member(user.id)
     
 def add_to_my_role_1(update, context):
     user_id = int(update.message.text)
-    context.bot_data[BOT_DATA_KEY]['my_role_1'].add_member(user_id)
+    context.roles['my_role_1'].add_member(user_id)
 
 ...
 

--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -74,3 +74,4 @@ Unfortunately `RolesHandler(my_conversation_handler, roles=roles)` does *not* wo
 ## Authors
 
 *   [Hinrich Mahler](https://github.com/bibo-joshi)
+*   [GrandMoffPinky](https://github.com/grandmoffpinky)

--- a/ptbcontrib/roles/__init__.py
+++ b/ptbcontrib/roles/__init__.py
@@ -17,7 +17,7 @@
 """This module contains classes and methods for granular, hierarchical user access management."""
 
 from .roles import Role, Roles, ChatAdminsRole, ChatCreatorRole, InvertedRole
-from .roleshandler import RolesHandler, setup_roles, BOT_DATA_KEY
+from .roleshandler import RolesHandler, setup_roles, BOT_DATA_KEY, RolesBotData
 
 __all__ = [
     'Roles',
@@ -28,4 +28,5 @@ __all__ = [
     'RolesHandler',
     'setup_roles',
     'BOT_DATA_KEY',
+    'RolesBotData',
 ]

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -30,16 +30,35 @@ BOT_DATA_KEY: str = 'ptbcontrib_roles_bot_data_key'
 
 
 class RolesBotData(ABC):
-    """Fill me"""
+    """
+    Fill me
+
+    Defines the abstract class RolesBotData.
+    It has two abstract methods: get_roles and set_roles
+    """
 
     @abstractmethod
     def get_roles(self) -> Optional[Roles]:
-        """Fil me"""
+        """
+        Fill me
+
+        An abstract method meant to fetch an existing set of roles.
+
+        Returns:
+            The preexisting :class: 'Roles' instance, if there is one
+        """
         ...
 
     @abstractmethod
     def set_roles(self,roles: Roles) -> None:
-        """Fill me"""
+        """
+        Fill me
+
+        An abstract method that implements a set of roles.
+
+        Args:
+            roles (:class: 'Roles'): The set of roles
+        """
         ...
 
 
@@ -47,8 +66,12 @@ def setup_roles(dispatcher: Dispatcher) -> Roles:
     """
     Change me!
 
-    Retrieves the :class:`ptbcontrib.roles.Roles` instance stored in :attr:`dispatcher.bot_data`
-    or creates a new one and saves it under :attr:`BOT_DATA_KEY`.
+    ??? Can we be sure that there is either an instance of Roles or a dict? Can there be nothing?
+
+    Checks if the :attr: 'dispatcher.bot_data' stores an instance
+    of the class :class:`ptbcontrib.roles.Roles` or a dict.
+    In the first case, either the existing instance is retrieved or a new one is created and
+    saved under :attr:`BOT_DATA_KEY`.
 
     Args:
         dispatcher (:class:`telegram.ext.Dispatcher`): The dispatcher

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -31,10 +31,8 @@ BOT_DATA_KEY: str = 'ptbcontrib_roles_bot_data_key'
 
 class RolesBotData(ABC):
     """
-    Fill me
-
-    Defines the abstract class RolesBotData.
-    It has two abstract methods: get_roles and set_roles
+    Abstract base class providing an interface to be used by :meth:`set_roles`.
+    Inherit from this class when using a custom type for ``bot_data``
     """
 
     @abstractmethod


### PR DESCRIPTION
Added an interface class 'RolesBotData(ABC)' in order to prepare roles_handler for non-dict `bot_data`. By adding an interface class, we have a clear & reliable way to get/set the roles object on custom `bot_data`.

I hope this is a suitable addition to make this work in v13.6.