### PR TITLE
Improve PostgresSQL Persistence class

### DIFF
--- a/ptbcontrib/postgres_persistence/README.md
+++ b/ptbcontrib/postgres_persistence/README.md
@@ -1,37 +1,23 @@
 # Persistence class with Postgresql database as backend
 
-## Notes
-Data needs to be JSON-serializable & will be written to the DB only on shutdown.
-
 ## How to use
 
 ```python
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, scoped_session
-
 from ptbcontrib.postgres_persistence import PostgresPersistence
 
 
 # Your Postgresql database URL
 DB_URI = "postgresql://username:pw@hostname:port/db_name"
 
-# SQLAlchemy session maker
-def start_session() -> scoped_session:
-    engine = create_engine(DB_URI, client_encoding="utf8")
-    return scoped_session(sessionmaker(bind=engine, autoflush=False))
-
-# start the session
-session = start_session()
-
-# And pass it in Updater...
-updater = Updater(...., persistence=PostgresPersistence(session))
+# And pass it in Updater
+updater = Updater(..., persistence=PostgresPersistence(url=DB_URI))
 ```
 
 ## Requirements
 
 *   `python-telegram-bot>=12.0`
 *   `SQLAlchemy`
-*   `ujson`
+*   `ujson` (Optional)
 
 ## Authors
 

--- a/ptbcontrib/postgres_persistence/postgrespersistence.py
+++ b/ptbcontrib/postgres_persistence/postgrespersistence.py
@@ -21,7 +21,7 @@
 
 from logging import getLogger
 from collections import defaultdict
-from typing import Dict, Any, Callable
+from typing import Dict, Tuple, Any, Callable, Optional
 
 from telegram.ext import DictPersistence
 from telegram.utils.helpers import (
@@ -29,10 +29,14 @@ from telegram.utils.helpers import (
     decode_conversations_from_json,
 )
 
-from sqlalchemy.orm import scoped_session
+from sqlalchemy import create_engine
 from sqlalchemy.sql import text
+from sqlalchemy.orm import sessionmaker, scoped_session
 
-import ujson as json
+try:
+    import ujson as json
+except ImportError:
+    import json  # type: ignore[no-redef]
 
 
 class PostgresPersistence(DictPersistence):
@@ -47,7 +51,10 @@ class PostgresPersistence(DictPersistence):
             persistence class.
 
     Args:
-        session (:obj:`scoped_session`, Required): sqlalchemy scoped session.
+        url (:obj:`str`, Optional) the postgresql database url.
+        session (:obj:`scoped_session`, Optional): sqlalchemy scoped session.
+        on_flush (:obj:`bool`, optional): if set to :obj:`True` :class:`PostgresPersistence`
+            will only update bot/chat/user data in database on shutdown.
         store_user_data (:obj:`bool`, optional): Whether user_data should be saved by this
             persistence class. Default is :obj:`True`.
         store_chat_data (:obj:`bool`, optional): Whether user_data should be saved by this
@@ -57,9 +64,12 @@ class PostgresPersistence(DictPersistence):
 
     """
 
+    # pylint: disable=R0913
     def __init__(
         self,
-        session: scoped_session,
+        url: str = None,
+        session: scoped_session = None,
+        on_flush: bool = False,
         store_user_data: bool = True,
         store_chat_data: bool = True,
         store_bot_data: bool = True,
@@ -72,10 +82,22 @@ class PostgresPersistence(DictPersistence):
         )
 
         self.logger = getLogger(__name__)
-        if not isinstance(session, scoped_session):
-            raise TypeError("session must be `sqlalchemy.orm.scoped_session` object")
 
-        self._session = session
+        if url:
+            if not url.startswith("postgresql://"):
+                raise TypeError(f"{url} isn't a valid PostgreSQL database URL.")
+            engine = create_engine(url, client_encoding="utf8")
+            self._session = scoped_session(sessionmaker(bind=engine, autoflush=False))
+
+        elif session:
+            if not isinstance(session, scoped_session):
+                raise TypeError("session must needs to be `sqlalchemy.orm.scoped_session` object")
+            self._session = session
+
+        else:
+            raise TypeError("You must needs to provide either url or session.")
+
+        self.on_flush = on_flush
         self.__init_database()
         self.__load_database()
 
@@ -93,7 +115,7 @@ class PostgresPersistence(DictPersistence):
             data_ = self._session.execute(text("SELECT data FROM persistence")).first()
             data = data_[0] if data_ is not None else {}
 
-            self.logger.info("Loading database \n%s", data)
+            self.logger.info("Loading database....")
             self._chat_data = defaultdict(dict, self._key_mapper(data.get("chat_data", {}), int))
             self._user_data = defaultdict(dict, self._key_mapper(data.get("user_data", {}), int))
             self._bot_data = data.get("bot_data", {})
@@ -115,28 +137,68 @@ class PostgresPersistence(DictPersistence):
             "bot_data": self.bot_data,
             "conversations": encode_conversations_to_json(self._conversations),
         }
-        self.logger.info("Dumping %s", to_dump)
+        self.logger.debug("Dumping %s", to_dump)
         return json.dumps(to_dump)
 
-    def flush(self) -> None:
-        """Will be called by :class:`telegram.ext.Updater` upon receiving a stop signal. Gives the
-        persistence a chance to finish up saving or close a database connection gracefully.
-        """
-
-        self.logger.info("Saving user/chat/bot data before shutdown")
+    def _update_database(self) -> None:
+        self.logger.debug("Updating database...")
         try:
-            self._session.execute("DELETE FROM persistence")
-            insert_qry = "INSERT INTO persistence (data) VALUES (:jsondata)"
+            insert_qry = "UPDATE persistence SET data = :jsondata"
             params = {"jsondata": self._dump_into_json()}
             self._session.execute(text(insert_qry), params)
             self._session.commit()
         except Exception as excp:  # pylint: disable=W0703
             self._session.close()
             self.logger.error(
-                "Failed to save user/chat/bot data before shutdown...\nLogging exception:",
+                "Failed to save data in the database.\nLogging exception: ",
                 exc_info=excp,
             )
-        else:
-            self.logger.info("SUCESS! saved user/chat/bot data into database.")
 
+    def update_conversation(
+        self, name: str, key: Tuple[int, ...], new_state: Optional[object]
+    ) -> None:
+        """Will update the conversations for the given handler.
+        Args:
+            name (:obj:`str`): The handler's name.
+            key (:obj:`tuple`): The key the state is changed for.
+            new_state (:obj:`tuple`
+        """
+        super().update_conversation(name, key, new_state)
+        if not self.on_flush:
+            self._update_database()
+
+    def update_user_data(self, user_id: int, data: Dict) -> None:
+        """Will update the user_data (if changed).
+        Args:
+            user_id (:obj:`int`): The user the data might have been changed for.
+            data (:obj:`dict`): The :attr:`telegram.ext.Dispatcher.user_data` ``[user_id]``.
+        """
+        super().update_user_data(user_id, data)
+        if not self.on_flush:
+            self._update_database()
+
+    def update_chat_data(self, chat_id: int, data: Dict) -> None:
+        """Will update the chat_data (if changed).
+        Args:
+            chat_id (:obj:`int`): The chat the data might have been changed for.
+            data (:obj:`dict`): The :attr:`telegram.ext.Dispatcher.chat_data` ``[chat_id]``.
+        """
+        super().update_chat_data(chat_id, data)
+        if not self.on_flush:
+            self._update_database()
+
+    def update_bot_data(self, data: Dict) -> None:
+        """Will update the bot_data (if changed).
+        Args:
+            data (:obj:`dict`): The :attr:`telegram.ext.Dispatcher.bot_data`.
+        """
+        super().update_bot_data(data)
+        if not self.on_flush:
+            self._update_database()
+
+    def flush(self) -> None:
+        """Will be called by :class:`telegram.ext.Updater` upon receiving a stop signal. Gives the
+        persistence a chance to finish up saving or close a database connection gracefully.
+        """
+        self._update_database()
         self.logger.info("Closing database...")

--- a/ptbcontrib/postgres_persistence/requirements.txt
+++ b/ptbcontrib/postgres_persistence/requirements.txt
@@ -1,3 +1,2 @@
 python-telegram-bot>=12.0
 SQLAlchemy
-ujson


### PR DESCRIPTION
- Added `url` parameter, now it's not necessary to manually build scoped session. though it can still be passed instead or `url` if needed.
- Added `on_flush` parameter when set True persistence will only save data on shutdown else it'll update the database on every update.
- Improved data saving query now it'll update the existing data in table instead of deleting and adding new data.