### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Updates the dependencies of the GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "friday"

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -3,16 +3,15 @@ name: 'Lock Closed Threads'
 on:
   schedule:
     - cron: '8 4 * * *'
-    - cron: '42 17 * * *'
 
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2.0.1
+      - uses: dessant/lock-threads@v4.0.0
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: '1'
+          issue-lock-inactive-days: '7'
           issue-lock-reason: ''
-          pr-lock-inactive-days: '1'
+          pr-lock-inactive-days: '7'
           pr-lock-reason: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,14 @@ jobs:
             test-build: True
       fail-fast: False
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # makes sure that we also fetch main
       - name: Initialize vendored libs
         run:
           git submodule update --init --recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
* Add dependabot to update the CI dependencie
* manually update the dependencies for now
* lock inactive threads only after 1 week instead of 1 day (as we do in the main repo by now)
* run the locking workflow only once each day as I rather frequently see the job failing due to rate limits