### PR TITLE
Fixing jobstore.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
     -   id: black
         args:
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/pylint
-    rev: v2.16.4
+    rev: v3.0.0a6
     hooks:
     -   id: pylint
         name: pylint
@@ -25,7 +25,7 @@ repos:
         #  run pylint across multiple cpu cores to speed it up-
         - --jobs=0  # See https://pylint.pycqa.org/en/latest/user_guide/run.html?#parallel-execution to know more
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.1.1
     hooks:
     -   id: mypy
         exclude: ^tests/

--- a/ptbcontrib/ptb_sqlalchemy_jobstore/jobstore.py
+++ b/ptbcontrib/ptb_sqlalchemy_jobstore/jobstore.py
@@ -83,9 +83,13 @@ class PTBSQLAlchemyJobStore(SQLAlchemyJobStore):
         # we'll get incorrect argument instead of CallbackContext.
         prepped_job = APSJob.__new__(APSJob)
         prepped_job.__setstate__(job.__getstate__())
+        # Get the tg_job instance in memory or the one that we deserialized during _reconstitute (first arg in args)
+        if len(job.args) == 1:
+            tg_job = Job._from_aps_job(job)  # pylint: disable=W0212
+        else:
+            tg_job = job.args[0]  # take the tg_job instance deserialized before during _reconstitute
         # Extract relevant information from the job and
         # store it in the job's args.
-        tg_job = Job._from_aps_job(job)  # pylint: disable=W0212
         prepped_job.args = (
             tg_job.name,
             tg_job.data,

--- a/ptbcontrib/ptb_sqlalchemy_jobstore/jobstore.py
+++ b/ptbcontrib/ptb_sqlalchemy_jobstore/jobstore.py
@@ -83,11 +83,13 @@ class PTBSQLAlchemyJobStore(SQLAlchemyJobStore):
         # we'll get incorrect argument instead of CallbackContext.
         prepped_job = APSJob.__new__(APSJob)
         prepped_job.__setstate__(job.__getstate__())
-        # Get the tg_job instance in memory or the one that we deserialized during _reconstitute (first arg in args)
+        # Get the tg_job instance in memory or the one that we deserialized during _reconstitute
+        # (first arg in args)
         if len(job.args) == 1:
             tg_job = Job._from_aps_job(job)  # pylint: disable=W0212
         else:
-            tg_job = job.args[0]  # take the tg_job instance deserialized before during _reconstitute
+            # take the tg_job instance deserialized before during _reconstitute
+            tg_job = job.args[0]
         # Extract relevant information from the job and
         # store it in the job's args.
         prepped_job.args = (

--- a/tests/test_ptb_sqlalchemy_jobstore.py
+++ b/tests/test_ptb_sqlalchemy_jobstore.py
@@ -23,7 +23,6 @@ import platform
 
 import apscheduler.triggers.interval
 import pytest
-from apscheduler.triggers.base import BaseTrigger
 from telegram.ext import CallbackContext, JobQueue
 
 from ptbcontrib.ptb_sqlalchemy_jobstore import PTBSQLAlchemyJobStore  # noqa: E402

--- a/tests/test_ptb_sqlalchemy_jobstore.py
+++ b/tests/test_ptb_sqlalchemy_jobstore.py
@@ -90,8 +90,6 @@ class TestPTBJobstore:
         j_final = jq.scheduler.get_job(j1.job.id).reschedule(trigger)
         assert j_final.id == j1.job.id
 
-
-
     def test_remove_job(self, jq, jobstore):
         j1 = jq.run_once(dummy_job, 1)
         j2 = jq.run_once(dummy_job, 2)

--- a/tests/test_ptb_sqlalchemy_jobstore.py
+++ b/tests/test_ptb_sqlalchemy_jobstore.py
@@ -21,7 +21,9 @@ import logging
 import os
 import platform
 
+import apscheduler.triggers.interval
 import pytest
+from apscheduler.triggers.base import BaseTrigger
 from telegram.ext import CallbackContext, JobQueue
 
 from ptbcontrib.ptb_sqlalchemy_jobstore import PTBSQLAlchemyJobStore  # noqa: E402
@@ -80,6 +82,16 @@ class TestPTBJobstore:
         j3 = jq.run_once(dummy_job, 3)
         jobs = jobstore.get_all_jobs()
         assert jobs == [j1.job, j2.job, j3.job]
+
+    def test_operations_on_job(self, jq, jobstore):
+        trigger = apscheduler.triggers.interval.IntervalTrigger(seconds=3)
+        j1 = jq.run_once(dummy_job, 1)
+        jq.scheduler.get_job(j1.job.id).pause()
+        jq.scheduler.get_job(j1.job.id).resume()
+        j_final = jq.scheduler.get_job(j1.job.id).reschedule(trigger)
+        assert j_final.id == j1.job.id
+
+
 
     def test_remove_job(self, jq, jobstore):
         j1 = jq.run_once(dummy_job, 1)


### PR DESCRIPTION
Problem:  pause and rescheduler jobs (serialized and deserialized obviously)

## Structure 
A TGJob `tg_job` is a telegram job and is based on a constructor with 5 args and a APScheduler Job `job` field
- `tg_job = TGJob(callback, data, name, chat_id, user_id)`: the actual callback, data, ecc we set
- `tg_job.job =APJob(callback=tg_job.run, args[application], name=name, **job_kwargs)`

So the TGJob wraps the APjob setting  the application (became the bot context) as parameter for the `tg_job.run`  function when the callback will be executed.

## Serialization
APScheduler so will try to serialize the `job` instance but `application` is a arg so it would have been serialized. Here we have our implementation of `SQLAlchemyJobStore` in jobstore.py.
### Adapter of SQLAlchemyJobStore 
When a job is going to be serialized we:
- copy the job
- get the `tg_job` instantiating the `self` of the job callback (tg_job.run remember?) **if the tg_job is in memory**
- settings the `job` args to tg_job parameters `[callback, data, name, chat_id, user_id]` so replacing the unique [`application`] arg.

then the job is serialized, remember with these key fields:
- callback = `tg_job.run` function literal (reference to the function not the instance obiouvsly)
- args = `[callback, data, name, chat_id, user_id]`

## Deserialization
When we want to reschedule or pause an existing job, we get the job:
- `job` deserialized
- create a `tg_job = TGGob(job.args)` (5 args)
- modify the `job` args to be 2 (not only application now). `tg_job` and `application`. The first is going to be the `self` argument, the second is the standard `application` argument that we started with before serialization

## Serialization of a deserialized job 
When we come to the serialization step this time we do not have a `tg_job` instance when trying to get the `self` from the `job.callback` function literal. `__self__ does not exists`. 

## Solution
So get the `tg_job` form the first argument we provided during deserialization that is the instance we need :)
 