### PR TITLE
Send logs to Telegram chat via HTTPHandler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     hooks:
     -   id: mypy
         exclude: ^tests/
+        additional_dependencies: ['types-requests']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.3.2
     hooks:

--- a/ptbcontrib/ptb_logging_to_chat/README.md
+++ b/ptbcontrib/ptb_logging_to_chat/README.md
@@ -1,0 +1,58 @@
+# Monitor your Telegram bot via chat
+
+Provides a `PTBChatLoggingHandler` class, which is a handler for the `logging` library.
+It allows to pipe application logs to a specified Telegram chat via the Telegram API.
+
+## Usage
+
+### Basic example
+
+```python
+import logging
+from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler
+
+logger = logging.getLogger(__name__)
+chat_id = -123456789
+
+logger.addHandler(PTBChatLoggingHandler("BOT_TOKEN", [logging.ERROR], chat_id))
+
+logger.error("something went wrong!")
+```
+
+Result:
+
+
+
+### Pretty example
+
+```python
+import logging
+from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler
+from telegram.constants import ParseMode
+
+logger = logging.getLogger(__name__)
+chat_id = -123456789
+LOG_FORMAT = "<code>%(asctime)s - %(name)s\t- %(levelname)s\t- %(message)s</code>"
+
+logger.addHandler(
+    PTBChatLoggingHandler("BOT_TOKEN", [logging.ERROR], chat_id, LOG_FORMAT, parse_mode=ParseMode.HTML)
+)
+
+logger.error("something went wrong!")
+```
+
+Result:
+
+### Note
+
+Bear in mind that most Python packages log a lot of debug information.
+Therefore it is not recommended to use `PTBChatLoggingHandler` for the root logger (a.k.a. `logging.getLogger()`) with the `logging.DEBUG` level.
+
+```python
+# this is a bad idea
+logging.getLogger().addHandler(PTBChatLoggingHandler("BOT_TOKEN", [logging.DEBUG], chat_id))
+```
+
+## Authors
+
+*   [alexeyqu](https://github.com/alexeyqu)

--- a/ptbcontrib/ptb_logging_to_chat/README.md
+++ b/ptbcontrib/ptb_logging_to_chat/README.md
@@ -25,7 +25,6 @@ Result:
 
 ![image](https://github.com/alexeyqu/ptbcontrib/assets/7394728/fae832a4-072d-4756-9525-eb97886b205c)
 
-
 ### Pretty example
 
 ```python
@@ -47,7 +46,6 @@ logger.error("something went wrong!")
 Result:
 
 ![image](https://github.com/alexeyqu/ptbcontrib/assets/7394728/59ca52bf-277a-4a4a-a8cb-5567fafc72e0)
-
 
 ### Note
 

--- a/ptbcontrib/ptb_logging_to_chat/__init__.py
+++ b/ptbcontrib/ptb_logging_to_chat/__init__.py
@@ -1,0 +1,21 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2023
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains code to pipe logs to a Telegram chat."""
+
+from .chat_logging_handler import PTBChatLoggingHandler
+
+__all__ = ["PTBChatLoggingHandler"]

--- a/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
+++ b/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
@@ -19,7 +19,7 @@
 """This module contains logging handler which pipes logs to a Telegram chat."""
 from logging import BASIC_FORMAT, Formatter, LogRecord
 from logging.handlers import HTTPHandler
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
 from telegram.constants import ParseMode
@@ -58,14 +58,19 @@ class PTBChatLoggingHandler(HTTPHandler):
         self.disable_notification = disable_notification
         self.disable_web_page_preview = disable_web_page_preview
 
-    def mapLogRecord(self, record: LogRecord) -> Dict:
-        return {
+    def mapLogRecord(self, record: LogRecord) -> Dict[str, Any]:
+        payload = {
             "text": self.format(record),
             "chat_id": self.chat_id,
-            "parse_mode": self.parse_mode,
-            "disable_notification": self.disable_notification,
-            "disable_web_page_preview": self.disable_web_page_preview,
-        }
+        }  # type: Dict[str, Any]
+        # could use a lambda here if more arguments needed
+        if self.parse_mode is not None:
+            payload["parse_mode"] = self.parse_mode
+        if self.disable_web_page_preview is not None:
+            payload["disable_web_page_preview"] = self.disable_web_page_preview
+        if self.disable_notification is not None:
+            payload["disable_notification"] = self.disable_notification
+        return payload
 
     def emit(self, record: LogRecord) -> None:
         """

--- a/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
+++ b/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
@@ -30,9 +30,17 @@ TELEGRAM_API_URL = "bot{token}/sendMessage"
 
 class PTBChatLoggingHandler(HTTPHandler):
     """
-    A handler class which writes logging records, appropriately formatted,
+    A handler class which sends the logging records, appropriately formatted,
     to a Telegram chat.
-    Args: TODO(alexeyqu)
+
+    Args:
+        token (str): The Telegram bot token.
+        levels (:obj:`list` of :obj:`int`): The logging levels handled.
+        chat_id (int): The ID of the recipient Telegram chat.
+        log_format (str): The format string for the logger.
+        parse_mode (:obj:`bool`, optional): The parse mode for Telegram, e.g. HTML.
+        disable_notification (:obj:`bool`, optional): The API flag to disable notifications.
+        disable_web_page_preview (:obj:`bool`, optional): The API flag to disable web page preview.
     """
 
     def __init__(
@@ -59,6 +67,15 @@ class PTBChatLoggingHandler(HTTPHandler):
         self.disable_web_page_preview = disable_web_page_preview
 
     def mapLogRecord(self, record: LogRecord) -> Dict[str, Any]:
+        """
+        Override the default HTTPHandler implementation of mapping the log record to data.
+
+        Args:
+            record (:obj:`LogRecord`): The entity to be logged.
+
+        Returns:
+            dict(str, :obj:`Any`): The payload for the requests.post call.
+        """
         payload = {
             "text": self.format(record),
             "chat_id": self.chat_id,
@@ -75,8 +92,10 @@ class PTBChatLoggingHandler(HTTPHandler):
     def emit(self, record: LogRecord) -> None:
         """
         Emit a record.
+        Sends the formatted log to Telegram API via requests.post method.
 
-        Send the record to the Web server as a percent-encoded dictionary
+        Args:
+            record (:obj:`LogRecord`): The entity to be logged.
         """
         if record.levelno in self.levels:
             try:

--- a/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
+++ b/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
@@ -23,7 +23,13 @@ from logging.handlers import HTTPHandler
 from typing import Any, Dict, List, Optional
 
 import requests
-from telegram.constants import ParseMode
+
+try:
+    # python-telegram-bot >= 20.0.0
+    from telegram.constants import ParseMode
+except ImportError:
+    # python-telegram-bot < 20.0.0
+    from telegram import ParseMode
 
 TELEGRAM_API_HOST = "api.telegram.org"
 TELEGRAM_API_URL = "bot{token}/sendMessage"

--- a/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
+++ b/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2023
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains logging handler which pipes logs to a Telegram chat."""
+from logging import BASIC_FORMAT, Formatter, LogRecord
+from logging.handlers import HTTPHandler
+from typing import Dict, List, Optional
+
+import requests
+from telegram.constants import ParseMode
+
+TELEGRAM_API_HOST = "api.telegram.org"
+TELEGRAM_API_URL = "bot{token}/sendMessage"
+
+
+class PTBChatLoggingHandler(HTTPHandler):
+    """
+    A handler class which writes logging records, appropriately formatted,
+    to a Telegram chat.
+    Args: TODO(alexeyqu)
+    """
+
+    def __init__(
+        self,
+        token: str,
+        levels: List[int],
+        chat_id: int,
+        *,
+        log_format: str = BASIC_FORMAT,
+        parse_mode: Optional[ParseMode] = None,
+        disable_notification: Optional[bool] = None,
+        disable_web_page_preview: Optional[bool] = None,
+    ):
+        # `method` and `secure` arguments are technically not needed as we use the requests library
+        # passing them for visibility
+        super().__init__(
+            TELEGRAM_API_HOST, TELEGRAM_API_URL.format(token=token), method="POST", secure=True
+        )
+        self.setFormatter(Formatter(log_format))
+        self.levels = levels
+        self.chat_id = str(chat_id)
+        self.parse_mode = parse_mode
+        self.disable_notification = disable_notification
+        self.disable_web_page_preview = disable_web_page_preview
+
+    def mapLogRecord(self, record: LogRecord) -> Dict:
+        return {
+            "text": self.format(record),
+            "chat_id": self.chat_id,
+            "parse_mode": self.parse_mode,
+            "disable_notification": self.disable_notification,
+            "disable_web_page_preview": self.disable_web_page_preview,
+        }
+
+    def emit(self, record: LogRecord) -> None:
+        """
+        Emit a record.
+
+        Send the record to the Web server as a percent-encoded dictionary
+        """
+        if record.levelno in self.levels:
+            try:
+                requests.post(
+                    f"https://{self.host}/{self.url}",
+                    data=self.mapLogRecord(record),
+                    headers={"content-type": "application/json"},
+                )
+            except Exception:  # pylint: disable=W0718
+                self.handleError(record)

--- a/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
+++ b/ptbcontrib/ptb_logging_to_chat/chat_logging_handler.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains logging handler which pipes logs to a Telegram chat."""
+import json
 from logging import BASIC_FORMAT, Formatter, LogRecord
 from logging.handlers import HTTPHandler
 from typing import Any, Dict, List, Optional
@@ -99,10 +100,20 @@ class PTBChatLoggingHandler(HTTPHandler):
         """
         if record.levelno in self.levels:
             try:
-                requests.post(
-                    f"https://{self.host}/{self.url}",
-                    data=self.mapLogRecord(record),
-                    headers={"content-type": "application/json"},
-                )
+                self._emit(self.mapLogRecord(record))
             except Exception:  # pylint: disable=W0718
                 self.handleError(record)
+
+    def _emit(self, data: Dict[str, Any]) -> None:
+        """
+        Emit a record.
+        Wrapper for `requests.post` for convenience.
+
+        Args:
+            dict(str, :obj:`Any`): The payload for the requests.post call.
+        """
+        requests.post(
+            f"https://{self.host}/{self.url}",
+            data=json.dumps(data),
+            headers={"content-type": "application/json"},
+        )

--- a/ptbcontrib/ptb_logging_to_chat/requirements.txt
+++ b/ptbcontrib/ptb_logging_to_chat/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/test_ptb_logging_to_chat.py
+++ b/tests/test_ptb_logging_to_chat.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2023
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+import logging
+
+import pytest
+import requests
+from telegram.constants import ParseMode
+from telegram.error import TelegramError
+
+from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler
+
+logger = logging.getLogger(__name__)
+
+TOKEN = "TOKEN"
+CHAT_ID_1 = -1000000000
+CHAT_ID_2 = -2000000000
+
+
+@pytest.fixture(scope="function")
+def argtest():
+    class TestArgs:
+        was_called = False
+
+        def __call__(self, *args, **kwargs):
+            self.was_called = True
+            self.args = list(args)
+            self.kwargs = kwargs
+
+    return TestArgs()
+
+
+@pytest.fixture(autouse=True)
+def clean_logging_handlers():
+    logger.handlers.clear()
+
+
+class TestPTBLoggingToChat:
+    @pytest.mark.parametrize(
+        "levels, chat_id, was_called, kwargs",
+        [
+            [
+                [logging.ERROR],
+                CHAT_ID_1,
+                True,
+                {
+                    "data": {
+                        "chat_id": str(CHAT_ID_1),
+                        "text": "ERROR:tests.test_ptb_logging_to_chat:message",
+                    },
+                    "headers": {
+                        "content-type": "application/json",
+                    },
+                },
+            ],
+            [[logging.WARNING], CHAT_ID_1, False, None],
+            [
+                [logging.WARNING, logging.ERROR],
+                CHAT_ID_1,
+                True,
+                {
+                    "data": {
+                        "chat_id": str(CHAT_ID_1),
+                        "text": "ERROR:tests.test_ptb_logging_to_chat:message",
+                    },
+                    "headers": {
+                        "content-type": "application/json",
+                    },
+                },
+            ],
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_send_log(self, bot, monkeypatch, argtest, levels, chat_id, was_called, kwargs):
+        logger.addHandler(PTBChatLoggingHandler(TOKEN, levels, chat_id))
+
+        monkeypatch.setattr(requests, "post", argtest)
+
+        logger.error("message")
+
+        assert argtest.was_called == was_called
+        if was_called:
+            assert argtest.kwargs == kwargs
+
+    async def test_send_2_chats(self, bot, monkeypatch, argtest):
+        logger.addHandler(PTBChatLoggingHandler(TOKEN, [logging.ERROR], CHAT_ID_1))
+        logger.addHandler(PTBChatLoggingHandler(TOKEN, [logging.WARNING], CHAT_ID_2))
+
+        monkeypatch.setattr(requests, "post", argtest)
+
+        logger.error("message")
+
+        assert argtest.was_called is True
+        assert argtest.kwargs == {
+            "data": {
+                "chat_id": str(CHAT_ID_1),
+                "text": "ERROR:tests.test_ptb_logging_to_chat:message",
+            },
+            "headers": {
+                "content-type": "application/json",
+            },
+        }
+
+        argtest.was_called = False
+        logger.warning("message")
+
+        assert argtest.was_called is True
+        assert argtest.kwargs == {
+            "data": {
+                "chat_id": str(CHAT_ID_2),
+                "text": "WARNING:tests.test_ptb_logging_to_chat:message",
+            },
+            "headers": {
+                "content-type": "application/json",
+            },
+        }
+
+    async def test_send_html_encoded(self, bot, monkeypatch, argtest):
+        logger.addHandler(
+            PTBChatLoggingHandler(
+                TOKEN,
+                [logging.ERROR],
+                CHAT_ID_1,
+                log_format="<code>%(name)s\t- %(levelname)s\t- %(message)s</code>",
+                parse_mode=ParseMode.HTML,
+            )
+        )
+
+        monkeypatch.setattr(requests, "post", argtest)
+
+        logger.error("message")
+
+        assert argtest.was_called is True
+        assert argtest.kwargs == {
+            "data": {
+                "chat_id": str(CHAT_ID_1),
+                "text": "<code>tests.test_ptb_logging_to_chat\t- ERROR\t- message</code>",
+                "parse_mode": ParseMode.HTML,
+            },
+            "headers": {
+                "content-type": "application/json",
+            },
+        }
+
+    async def test_send_exception(self, bot, monkeypatch, argtest, capsys):
+        logger.addHandler(PTBChatLoggingHandler(TOKEN, [logging.ERROR], CHAT_ID_1))
+
+        def mock(**_kw):
+            raise TelegramError("Error")
+
+        monkeypatch.setattr(requests, "post", mock)
+
+        logger.error("message")
+
+        assert argtest.was_called is False
+        captured = capsys.readouterr()
+        assert "--- Logging error ---" in captured.err
+        assert "Message: 'message'" in captured.err

--- a/tests/test_ptb_logging_to_chat.py
+++ b/tests/test_ptb_logging_to_chat.py
@@ -19,8 +19,13 @@
 import logging
 
 import pytest
-from telegram.constants import ParseMode
-from telegram.error import TelegramError
+
+try:
+    # python-telegram-bot >= 20.0.0
+    from telegram.constants import ParseMode
+except ImportError:
+    # python-telegram-bot < 20.0.0
+    from telegram import ParseMode
 
 from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler
 
@@ -134,7 +139,7 @@ class TestPTBLoggingToChat:
         logger.addHandler(PTBChatLoggingHandler(TOKEN, [logging.ERROR], CHAT_ID_1))
 
         def mock(**_kw):
-            raise TelegramError("Error")
+            raise RuntimeError("Error")
 
         monkeypatch.setattr(PTBChatLoggingHandler, "_emit", mock)
 


### PR DESCRIPTION
# Monitor your Telegram bot via chat

Provides a `PTBChatLoggingHandler` class, which is a handler for the `logging` library. <br>
It allows to pipe application logs to a specified Telegram chat via the Telegram API.

Under the hood it leverages [the Telegram API sendMessage endpoint](https://core.telegram.org/method/messages.sendMessage), calling it via the `requests.post` method.

## Usage

### Basic example

```python
import logging
from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler

logger = logging.getLogger(__name__)
chat_id = -123456789

logging.getLogger().addHandler(PTBChatLoggingHandler("BOT_TOKEN", [logging.ERROR], chat_id))

logger.error("something went wrong!")
```

Result:

![image](https://github.com/alexeyqu/ptbcontrib/assets/7394728/fae832a4-072d-4756-9525-eb97886b205c)


### Pretty example

```python
import logging
from ptbcontrib.ptb_logging_to_chat import PTBChatLoggingHandler
from telegram.constants import ParseMode

logger = logging.getLogger(__name__)
chat_id = -123456789
LOG_FORMAT = "<code>%(asctime)s - %(name)s\t- %(levelname)s\t- %(message)s</code>"

logging.getLogger().addHandler(
    PTBChatLoggingHandler("BOT_TOKEN", [logging.ERROR], chat_id, LOG_FORMAT, parse_mode=ParseMode.HTML)
)

logger.error("something went wrong!")
```

Result:

![image](https://github.com/alexeyqu/ptbcontrib/assets/7394728/59ca52bf-277a-4a4a-a8cb-5567fafc72e0)
