### PR TITLE
Fixes for `roles`

### DIFF
--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -4,7 +4,7 @@ Provides classes and methods for granular, hierarchical user access management. 
 
 ```python
 from telegram import Update
-from telegram.ext import TypeHandler, ApplicationBuilder, MessageHandler, SomeHandler
+from telegram.ext import TypeHandler, ApplicationBuilder, MessageHandler, SomeHandler, filters
 from ptbcontrib.roles import setup_roles, RolesHandler, Role
 
 
@@ -33,7 +33,7 @@ async def post_init(application):
     if 'my_role_2' not in roles:
         roles.add_role(name='my_role_2')
     
-    roles.add_admin('authors_user_id')
+    roles.add_admin(123)
     my_role_2 = roles['my_role_2']
     my_role_1.add_child_role(my_role_2)
 
@@ -41,7 +41,7 @@ async def post_init(application):
     application.add_handler(TypeHandler(Update, add_to_my_role_2))
     
     # Only the admin can add users to my_role_1
-    application.add_handler(RolesHandler(MessageHandler(Filters.text, add_to_my_role_1), roles=roles.admins))
+    application.add_handler(RolesHandler(MessageHandler(filters.text, add_to_my_role_1), roles=roles.admins))
     
     # This will be accessible by my_role_2, my_role_1 and the admin
     application.add_handler(RolesHandler(SomeHandler(...), roles=my_role_2))
@@ -51,20 +51,13 @@ async def post_init(application):
     
     # This will be accessible by anyone except my_role_1 and my_role_2
     application.add_handler(RolesHandler(SomeHandler(...), roles=~my_role_1))
-    
-    # This will be accessible only by the admins of the group the update was sent in
-    application.add_handler(RolesHandler(SomeHandler(...), roles=roles.chat_admins))
-    
-    # This will be accessible only by the creator of the group the update was sent in
-    application.add_handler(RolesHandler(SomeHandler(...), roles=roles.chat_creator))
 
     # You can compare the roles regarding hierarchy:
-    roles.ADMINS >= roles['my_role_1']  # True
-    roles.ADMINS >= roles['my_role_2']  # True
+    roles['my_role_1'] >= roles['my_role_2']  # True
     roles['my_role_1'] < roles['my_role_2']  # False
-    roles.ADMINS >= Role(...)  # False, since neither of those is a parent of the other
+    roles['my_role_1'] >= Role(...)  # False, since neither of those is a parent of the other
 
-application = ApplicationBuilder.token('TOKEN').post_init(post_init).build()
+application = ApplicationBuilder().token('TOKEN').post_init(post_init).build()
 ```
 
 Please see the docstrings for more details.

--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -23,7 +23,8 @@ async def post_init(application):
     # and before the polling starts.
     # This ensures that the roles are initialized *after* the
     # persistence has been loaded, if persistence is used.
-    # See also the wiki page at https://github.com/python-telegram-bot/python-telegram-bot/wiki/Making-your-bot-persistent
+    # See also the wiki page at
+    # https://github.com/python-telegram-bot/python-telegram-bot/wiki/Making-your-bot-persistent
     roles = setup_roles(application)
 
     if 'my_role_1' not in roles:
@@ -38,10 +39,12 @@ async def post_init(application):
     my_role_1.add_child_role(my_role_2)
 
     # Anyone can add themself to my_role_2
-    application.add_handler(TypeHandler(Update, add_to_my_role_2))
+    application.add_handler(RolesHandler(TypeHandler(Update, add_to_my_role_2), roles=None))
     
     # Only the admin can add users to my_role_1
-    application.add_handler(RolesHandler(MessageHandler(filters.TEXT, add_to_my_role_1), roles=roles.admins))
+    application.add_handler(
+        RolesHandler(MessageHandler(filters.TEXT, add_to_my_role_1), roles=roles.admins)
+    )
     
     # This will be accessible by my_role_2, my_role_1 and the admin
     application.add_handler(RolesHandler(SomeHandler(...), roles=my_role_2))

--- a/ptbcontrib/roles/README.md
+++ b/ptbcontrib/roles/README.md
@@ -41,7 +41,7 @@ async def post_init(application):
     application.add_handler(TypeHandler(Update, add_to_my_role_2))
     
     # Only the admin can add users to my_role_1
-    application.add_handler(RolesHandler(MessageHandler(filters.text, add_to_my_role_1), roles=roles.admins))
+    application.add_handler(RolesHandler(MessageHandler(filters.TEXT, add_to_my_role_1), roles=roles.admins))
     
     # This will be accessible by my_role_2, my_role_1 and the admin
     application.add_handler(RolesHandler(SomeHandler(...), roles=my_role_2))
@@ -55,7 +55,7 @@ async def post_init(application):
     # You can compare the roles regarding hierarchy:
     roles['my_role_1'] >= roles['my_role_2']  # True
     roles['my_role_1'] < roles['my_role_2']  # False
-    roles['my_role_1'] >= Role(...)  # False, since neither of those is a parent of the other
+    roles.admins >= Role(...)  # False, since neither of those is a parent of the other
 
 application = ApplicationBuilder().token('TOKEN').post_init(post_init).build()
 ```

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -27,6 +27,8 @@ from telegram.ext.filters import UpdateFilter
 _REPLACED_LOCK: str = "ptbcontrib_roles_replaced_lock"
 
 
+# We only inherit from UpdateFilter to get the nice syntax of the bitwise operators.
+# If not for that, we could do without inheritance.
 class Role(UpdateFilter):
     """This class represents a security level used by :class:`telegram.ext.Roles`. Roles have a
     hierarchy, i.e. a role can do everthing, its child roles can do. To compare two roles you may
@@ -132,6 +134,13 @@ class Role(UpdateFilter):
             self.__init_admin()
             self._admin_event.wait()
             self._admin.add_child_role(self)
+
+    def check_update(self, update: Update) -> bool:
+        """Check if the update is allowed by this role. This is just an alias for
+        :meth:`filter`.
+        """
+        # Override UpdateFilter.check_update to handle also updates that are not messages
+        return self.filter(update)
 
     @staticmethod
     def _parse_chat_id(chat_id: Union[int, List[int], Tuple[int, ...], None]) -> Set[int]:
@@ -421,8 +430,7 @@ class Roles(Mapping):
 
     def set_bot(self, bot: Bot) -> None:
         """If for some reason you can't pass the bot on initialization, you can set it with this
-        method. Make sure to set the bot before the first call of :attr:`chat_admins` or
-        :attr:`chat_creator`.
+        method.
 
         Args:
             bot (:class:`telegram.Bot`): The bot to set.

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -103,22 +103,25 @@ class RolesHandler(BaseHandler[Update, _CCT]):
 
     Args:
         handler (:class:`telegram.ext.BaseHandler`): The handler to wrap.
-        roles (:class:`ptbcontrib.roles.Roles`): The roles to apply to the handler. Can be combined
-            with bitwise operations.
+        roles (:class:`ptbcontrib.roles.Roles`| :obj:`None`): The roles to apply to the handler.
+            Can be combined with bitwise operations. :obj:`None` is accepted as input, in which
+            case no roles restrictions will be applied. This can be useful if you want to have
+            ``context.roles`` available without restricting access.
+
     """
 
     def __init__(
-        self, handler: BaseHandler[Update, _CCT], roles: Union[Role, InvertedRole]
+        self, handler: BaseHandler[Update, _CCT], roles: Union[Role, InvertedRole, None]
     ) -> None:
         self.handler = handler
-        self.roles: Union[Role, InvertedRole] = roles
+        self.roles: Union[Role, InvertedRole, None] = roles
         super().__init__(self.handler.callback)
 
     def check_update(self, update: object) -> Any:
         """Checks if the update should be handled."""
         if not isinstance(update, Update):
             return False
-        if self.roles.check_update(update):
+        if self.roles is None or self.roles.check_update(update):
             return self.handler.check_update(update)
         return False
 

--- a/ptbcontrib/roles/roleshandler.py
+++ b/ptbcontrib/roles/roleshandler.py
@@ -107,7 +107,9 @@ class RolesHandler(BaseHandler[Update, _CCT]):
             with bitwise operations.
     """
 
-    def __init__(self, handler: BaseHandler[Update, _CCT], roles: Role) -> None:
+    def __init__(
+        self, handler: BaseHandler[Update, _CCT], roles: Union[Role, InvertedRole]
+    ) -> None:
         self.handler = handler
         self.roles: Union[Role, InvertedRole] = roles
         super().__init__(self.handler.callback)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 from typing import Optional
 
 import pytest
-from telegram import Chat, Message, Update, User
+from telegram import CallbackQuery, Chat, Message, Update, User
 from telegram.ext import CallbackContext, MessageHandler, PicklePersistence, filters
 
 from ptbcontrib.roles import BOT_DATA_KEY, Role, Roles, RolesBotData, RolesHandler, setup_roles
@@ -292,6 +292,20 @@ class TestRole:
             assert (Role(1) | ~Role(2)).check_update(update)
         finally:
             role._admin.kick_member(0)
+
+    def test_non_message_update(self, update, role):
+        update.message = None
+        assert not role.check_update(update)
+
+        update.callback_query = CallbackQuery(
+            id="id",
+            from_user=User(id=0, is_bot=False, first_name="first_name"),
+            chat_instance="chat_instance",
+        )
+        assert not role.check_update(update)
+
+        role.add_member(0)
+        assert role.check_update(update)
 
     def test_pickle(self, role, parent_role):
         role.add_member([0, 1, 3])


### PR DESCRIPTION
Closes #89 

Let me address the reports in #89 that I did not change anything for:

> 4. [line 14](https://github.com/python-telegram-bot/ptbcontrib/blob/c111451cd93be9481bc82fdf91d1ce6d02662acb/ptbcontrib/roles/README.md?plain=1#L14) `CallbackContext` has no attribute 'roles'

That's set by the `RolesHandler`:

https://github.com/python-telegram-bot/ptbcontrib/blob/c111451cd93be9481bc82fdf91d1ce6d02662acb/ptbcontrib/roles/roleshandler.py#L123-L130

> 5. [line 18](https://github.com/python-telegram-bot/ptbcontrib/blob/c111451cd93be9481bc82fdf91d1ce6d02662acb/ptbcontrib/roles/README.md?plain=1#L18) Same as line 14

No, the name of the role differs

> 6. Didn't start bot by using `application.run_polling()`

For showcases how roles can be set up, it doesn't show how to run the bot. Especially since `run_webhook` or a manual launch sequence would work just as well :)

> 8. [line 41](https://github.com/python-telegram-bot/ptbcontrib/blob/c111451cd93be9481bc82fdf91d1ce6d02662acb/ptbcontrib/roles/README.md?plain=1#L41) This update blocks any other update, it should be at the bottom

As stated in the [off-topic group](https://t.me/pythontelegrambottalk/241139) my goal here is not to make a completely reasonable, fully working example, but to  show some general mechanism.

> 10. IMO using `SomeHandler` which isn't an actual python-telegram-bot handler is confusing

This is just to showcase that any handler should work

@DonutByte let me ping you as FYI