### PR TITLE
Fixed problem in job deserialization caused by 20.4 version bump

### DIFF
--- a/ptbcontrib/ptb_jobstores/ptb_adapter.py
+++ b/ptbcontrib/ptb_jobstores/ptb_adapter.py
@@ -83,8 +83,8 @@ class PTBStoreAdapter:
         )
         job._modify(  # pylint: disable=W0212
             args=(
-                tg_job,
                 self.application,
+                tg_job,
             )
         )
         return job

--- a/ptbcontrib/ptb_jobstores/ptb_adapter.py
+++ b/ptbcontrib/ptb_jobstores/ptb_adapter.py
@@ -53,12 +53,9 @@ class PTBStoreAdapter:
         # we'll get incorrect argument instead of CallbackContext.
         prepped_job = APSJob.__new__(APSJob)
         prepped_job.__setstate__(job.__getstate__())
-        # Get the tg_job instance in memory
-        # or the one that we deserialized during _reconstitute (first arg in args)
-        if len(job.args) == 1:
-            tg_job = Job._from_aps_job(job)  # pylint: disable=W0212
-        else:
-            tg_job = job.args[0]
+        # Get the tg_job instance in memory or the one that
+        # we deserialized during _reconstitute (second arg in args)
+        tg_job = job.args[1]
         # Extract relevant information from the job and
         # store it in the job's args.
         prepped_job.args = (

--- a/tests/test_ptb_jobstores.py
+++ b/tests/test_ptb_jobstores.py
@@ -83,7 +83,7 @@ class TestPTBJobstore:
         job = jobstore.lookup_job(initial_job.id)
         assert job == initial_job.job
         assert job.name == initial_job.job.name
-        assert job.args[0].callback is initial_job.callback is dummy_job
+        assert job.args[1].callback is initial_job.callback is dummy_job
 
     def test_non_existent_job(self, jobstore):
         assert jobstore.lookup_job("foo") is None


### PR DESCRIPTION
In new version we get 2 parameters from job args, the second is set by ptb to be the tg_job. So if the job is new, the second parameter come from ptb and is the tg job. If we modify a job the second parameter is set by us as second arg and we do not have issues at all. Solution is cleaner than before  
close #91