### PR TITLE
`InvertedRole` non-message updates fix

### DIFF
--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -396,6 +396,13 @@ class InvertedRole(UpdateFilter):
         super().__init__(name=f"<inverted {role}>", data_filter=False)
         self.role = role
 
+    def check_update(self, update: Update) -> bool:
+        """Check if the update is allowed by this role. This is just an alias for
+        :meth:`filter`.
+        """
+        # Override UpdateFilter.check_update to handle also updates that are not messages
+        return self.filter(update)
+
     def filter(self, update: Update) -> bool:
         """Checks if the update should be handled."""
         return self.role.filter(update, inverted=True)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -296,6 +296,7 @@ class TestRole:
     def test_non_message_update(self, update, role):
         update.message = None
         assert not role.check_update(update)
+        assert not (~role).check_update(update)
 
         update.callback_query = CallbackQuery(
             id="id",
@@ -303,9 +304,11 @@ class TestRole:
             chat_instance="chat_instance",
         )
         assert not role.check_update(update)
+        assert (~role).check_update(update)
 
         role.add_member(0)
         assert role.check_update(update)
+        assert not (~role).check_update(update)
 
     def test_pickle(self, role, parent_role):
         role.add_member([0, 1, 3])


### PR DESCRIPTION
Following up on the problem I found [recently](https://github.com/python-telegram-bot/ptbcontrib/issues/89#issuecomment-1672157065) where `InvertedRole`  would not handle non-message updates.

I have added the `check_update` as I mentioned in the [comment](https://github.com/python-telegram-bot/ptbcontrib/issues/89#issuecomment-1672157065) and added tests.

This is my first time contributing to PTB so I'm not sure if I am doing this correctly :)
