### PR TITLE
Refactor ptb_jobstores for separation of modules & dependencies

### DIFF
--- a/ptbcontrib/ptb_jobstores/README.md
+++ b/ptbcontrib/ptb_jobstores/README.md
@@ -48,7 +48,9 @@ And use `requirements_mongodb.txt`.
 
 To install this extension separately, use:
 
-    $ pip install "ptbcontrib[ptb_jobstores_mongodb] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```bash
+$ pip install "ptbcontrib[ptb_jobstores_mongodb] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```
 
 Or, if you are using SQLAlchemy:
 *   `SQLAlchemy==1.4.46`
@@ -57,7 +59,9 @@ And use `requirements_sqlalchemy.txt`.
 
 To install this extension separately, use:
 
-    $ pip install "ptbcontrib[ptb_jobstores_sqlalchemy] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```bash
+$ pip install "ptbcontrib[ptb_jobstores_sqlalchemy] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```
 ## Authors
 
 *   [Niko Bolg](https://github.com/nkbolg)

--- a/ptbcontrib/ptb_jobstores/README.md
+++ b/ptbcontrib/ptb_jobstores/README.md
@@ -48,8 +48,8 @@ And use `requirements_mongodb.txt`.
 
 To install this extension separately, use:
 
-```bash
-$ pip install "ptbcontrib[ptb_jobstores_mongodb] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```shell
+pip install "ptbcontrib[ptb_jobstores_mongodb] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
 ```
 
 Or, if you are using SQLAlchemy:
@@ -59,8 +59,8 @@ And use `requirements_sqlalchemy.txt`.
 
 To install this extension separately, use:
 
-```bash
-$ pip install "ptbcontrib[ptb_jobstores_sqlalchemy] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
+```shell
+pip install "ptbcontrib[ptb_jobstores_sqlalchemy] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
 ```
 ## Authors
 

--- a/ptbcontrib/ptb_jobstores/README.md
+++ b/ptbcontrib/ptb_jobstores/README.md
@@ -13,7 +13,7 @@ The provided adapter erases all problematic fields and changes `telegram.ext.Job
 ### Usage
 ```python
 from telegram.ext import Application
-from ptbcontrib.ptb_mongodb_jobstore import PTBMongoDBJobStore
+from ptbcontrib.ptb_jobstores.mongodb import PTBMongoDBJobStore
 
 DB_URI = "mongodb://botuser:botpassword@localhost:27017/admin?retryWrites=true&w=majority"
 
@@ -35,11 +35,23 @@ use `job_kwargs` parameter that accepts arbitrary arguments as a dictionary and 
 For more information please have a look at APS scheduler's documentation about adding jobs by clicking [here](https://apscheduler.readthedocs.io/en/stable/userguide.html#adding-jobs).
 
 ## Requirements
+Main requirement includes:
 
 *   `python-telegram-bot[job-queue]~=20.0`
+
+
+For each Python ORM, you need to install the corresponding package:
+
+If you are using PyMongo:
 *   `pymongo>=4.1,<5`
+
+And use requirements_mongodb.txt.
+
+
+Or, if you are using SQLAlchemy:
 *   `SQLAlchemy==1.4.46`
 
+And use requirements_sqlalchemy.txt.
 ## Authors
 
 *   [Niko Bolg](https://github.com/nkbolg)

--- a/ptbcontrib/ptb_jobstores/README.md
+++ b/ptbcontrib/ptb_jobstores/README.md
@@ -39,19 +39,25 @@ Main requirement includes:
 
 *   `python-telegram-bot[job-queue]~=20.0`
 
-
 For each Python ORM, you need to install the corresponding package:
 
 If you are using PyMongo:
 *   `pymongo>=4.1,<5`
 
-And use requirements_mongodb.txt.
+And use `requirements_mongodb.txt`.
 
+To install this extension separately, use:
+
+    $ pip install "ptbcontrib[ptb_jobstores_mongodb] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
 
 Or, if you are using SQLAlchemy:
 *   `SQLAlchemy==1.4.46`
 
-And use requirements_sqlalchemy.txt.
+And use `requirements_sqlalchemy.txt`.
+
+To install this extension separately, use:
+
+    $ pip install "ptbcontrib[ptb_jobstores_sqlalchemy] @ git+https://github.com/python-telegram-bot/ptbcontrib.git@main"
 ## Authors
 
 *   [Niko Bolg](https://github.com/nkbolg)

--- a/ptbcontrib/ptb_jobstores/__init__.py
+++ b/ptbcontrib/ptb_jobstores/__init__.py
@@ -14,8 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This module contains PTB JobStores."""
-from .mongodb import PTBMongoDBJobStore
-from .sqlalchemy import PTBSQLAlchemyJobStore
+"""This module contains PTB Store Adapter."""
+from .ptb_adapter import PTBStoreAdapter
 
-__all__ = ["PTBMongoDBJobStore", "PTBSQLAlchemyJobStore"]
+__all__ = ["PTBStoreAdapter"]

--- a/ptbcontrib/ptb_jobstores/mongodb/__init__.py
+++ b/ptbcontrib/ptb_jobstores/mongodb/__init__.py
@@ -1,0 +1,20 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2023
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains PTB MongoDB JobStore."""
+from .mongodb import PTBMongoDBJobStore
+
+__all__ = ["PTBMongoDBJobStore"]

--- a/ptbcontrib/ptb_jobstores/mongodb/mongodb.py
+++ b/ptbcontrib/ptb_jobstores/mongodb/mongodb.py
@@ -16,42 +16,17 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This file contains PTBSQLAlchemyJobStore."""
-import logging
-from typing import Any
-
+"""This file contains PTBMongoDBJobStore."""
 from apscheduler.job import Job as APSJob
-from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-from telegram.ext import Application
+from apscheduler.jobstores.mongodb import MongoDBJobStore
 
-from .ptb_adapter import PTBStoreAdapter
-
-logger = logging.getLogger(__name__)
+from ..ptb_adapter import PTBStoreAdapter
 
 
-class PTBSQLAlchemyJobStore(PTBStoreAdapter, SQLAlchemyJobStore):
+class PTBMongoDBJobStore(PTBStoreAdapter, MongoDBJobStore):
     """
-    Wraps apscheduler.SQLAlchemyJobStore to make :class:`telegram.ext.Job` class storable.
+    Wraps apscheduler.MongoDBJobStore to make :class:`telegram.ext.Job` class storable.
     """
-
-    def __init__(self, application: Application, **kwargs: Any) -> None:
-        """
-        Args:
-            application (:class:`telegram.ext.Application`): Application instance
-                that will be passed to CallbackContext when recreating jobs.
-            **kwargs (:obj:`dict`): Arbitrary keyword Arguments to be passed to
-                the SQLAlchemyJobStore constructor.
-        """
-
-        if "url" in kwargs and kwargs["url"].startswith("sqlite:///"):
-            logger.warning(
-                "Use of SQLite db is not supported  due to "
-                "multi-threading limitations of SQLite databases "
-                "You can still try to use it, but it will likely "
-                "behave differently from what you expect."
-            )
-
-        super().__init__(application, **kwargs)
 
     def add_job(self, job: APSJob) -> None:
         """

--- a/ptbcontrib/ptb_jobstores/mongodb/mongodb.py
+++ b/ptbcontrib/ptb_jobstores/mongodb/mongodb.py
@@ -20,7 +20,7 @@
 from apscheduler.job import Job as APSJob
 from apscheduler.jobstores.mongodb import MongoDBJobStore
 
-from ..ptb_adapter import PTBStoreAdapter
+from .. import PTBStoreAdapter
 
 
 class PTBMongoDBJobStore(PTBStoreAdapter, MongoDBJobStore):

--- a/ptbcontrib/ptb_jobstores/requirements.txt
+++ b/ptbcontrib/ptb_jobstores/requirements.txt
@@ -1,0 +1,2 @@
+-r requirements_mongodb.txt
+-r requirements_sqlalchemy.txt

--- a/ptbcontrib/ptb_jobstores/requirements.txt
+++ b/ptbcontrib/ptb_jobstores/requirements.txt
@@ -1,3 +1,0 @@
-python-telegram-bot[job-queue]~=20.4
-pymongo>=4.1,<5
-SQLAlchemy~=1.4.46

--- a/ptbcontrib/ptb_jobstores/requirements_mongodb.txt
+++ b/ptbcontrib/ptb_jobstores/requirements_mongodb.txt
@@ -1,0 +1,2 @@
+python-telegram-bot[job-queue]~=20.4
+pymongo>=4.1,<5

--- a/ptbcontrib/ptb_jobstores/requirements_sqlalchemy.txt
+++ b/ptbcontrib/ptb_jobstores/requirements_sqlalchemy.txt
@@ -1,0 +1,2 @@
+python-telegram-bot[job-queue]~=20.4
+SQLAlchemy~=1.4.46

--- a/ptbcontrib/ptb_jobstores/sqlalchemy/__init__.py
+++ b/ptbcontrib/ptb_jobstores/sqlalchemy/__init__.py
@@ -1,0 +1,20 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2023
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains PTB SQLAlchemy JobStore."""
+from .sqlalchemy import PTBSQLAlchemyJobStore
+
+__all__ = ["PTBSQLAlchemyJobStore"]

--- a/ptbcontrib/ptb_jobstores/sqlalchemy/sqlalchemy.py
+++ b/ptbcontrib/ptb_jobstores/sqlalchemy/sqlalchemy.py
@@ -16,17 +16,42 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-"""This file contains PTBMongoDBJobStore."""
+"""This file contains PTBSQLAlchemyJobStore."""
+import logging
+from typing import Any
+
 from apscheduler.job import Job as APSJob
-from apscheduler.jobstores.mongodb import MongoDBJobStore
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from telegram.ext import Application
 
-from .ptb_adapter import PTBStoreAdapter
+from ..ptb_adapter import PTBStoreAdapter
+
+logger = logging.getLogger(__name__)
 
 
-class PTBMongoDBJobStore(PTBStoreAdapter, MongoDBJobStore):
+class PTBSQLAlchemyJobStore(PTBStoreAdapter, SQLAlchemyJobStore):
     """
-    Wraps apscheduler.MongoDBJobStore to make :class:`telegram.ext.Job` class storable.
+    Wraps apscheduler.SQLAlchemyJobStore to make :class:`telegram.ext.Job` class storable.
     """
+
+    def __init__(self, application: Application, **kwargs: Any) -> None:
+        """
+        Args:
+            application (:class:`telegram.ext.Application`): Application instance
+                that will be passed to CallbackContext when recreating jobs.
+            **kwargs (:obj:`dict`): Arbitrary keyword Arguments to be passed to
+                the SQLAlchemyJobStore constructor.
+        """
+
+        if "url" in kwargs and kwargs["url"].startswith("sqlite:///"):
+            logger.warning(
+                "Use of SQLite db is not supported  due to "
+                "multi-threading limitations of SQLite databases "
+                "You can still try to use it, but it will likely "
+                "behave differently from what you expect."
+            )
+
+        super().__init__(application, **kwargs)
 
     def add_job(self, job: APSJob) -> None:
         """

--- a/ptbcontrib/ptb_jobstores/sqlalchemy/sqlalchemy.py
+++ b/ptbcontrib/ptb_jobstores/sqlalchemy/sqlalchemy.py
@@ -24,7 +24,7 @@ from apscheduler.job import Job as APSJob
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from telegram.ext import Application
 
-from ..ptb_adapter import PTBStoreAdapter
+from .. import PTBStoreAdapter
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,24 @@ from typing import Dict, List, Union
 from setuptools import find_packages, setup
 
 _SUB_REQ_PATTERN = re.compile(r"requirements_(\w+).txt")
+_REC_REQ_PATTERN = re.compile(r"-r\s+(\S+)")
 
 
 def requirements(filename: Union[str, Path] = "requirements.txt") -> List[str]:
     """Build the requirements list for this project"""
     requirements_list = []
+    file_path = Path(filename)
 
-    with Path(filename).open(encoding="UTF-8") as file:
+    with file_path.open(encoding="UTF-8") as file:
         for install in file:
-            requirements_list.append(install.strip())
+            match = _REC_REQ_PATTERN.match(install)
+            if match:
+                # In case there is a line like '-r requirements_other.txt'
+                referenced_path = file_path.parent / match.group(1)
+                print(referenced_path)
+                requirements_list.extend(requirements(referenced_path))
+            else:
+                requirements_list.append(install.strip())
 
     return requirements_list
 

--- a/tests/test_ptb_jobstores.py
+++ b/tests/test_ptb_jobstores.py
@@ -25,7 +25,8 @@ import apscheduler.triggers.interval
 import pytest
 from telegram.ext import ApplicationBuilder, CallbackContext, JobQueue
 
-from ptbcontrib.ptb_jobstores import PTBMongoDBJobStore, PTBSQLAlchemyJobStore  # noqa: E402
+from ptbcontrib.ptb_jobstores.mongodb import PTBMongoDBJobStore  # noqa: E402
+from ptbcontrib.ptb_jobstores.sqlalchemy import PTBSQLAlchemyJobStore  # noqa: E402
 
 job_queue_params = [(PTBSQLAlchemyJobStore, {"url": "sqlite:///:memory:"})]
 job_queue_param_ids = ["SQLAlchemyJobStore"]


### PR DESCRIPTION
Separated SQLAlchemy and MongoDB jobstores into different packages to avoid unnecessary installation of both dependencies.

(I realized after commiting that I forgot to clear __init__.py file of ptb_jobstores package. This needs to be fixed.)