### PR TITLE
Log forwarder

### DIFF
--- a/ptbcontrib/log_forwarder/README.md
+++ b/ptbcontrib/log_forwarder/README.md
@@ -1,0 +1,14 @@
+# Logging handler for python-telegram-bot
+Extension to forward application logs to specific Telegram chats through a `logging.Handler` class.
+
+## Usage
+Initialize the log forwarder in your `on_startup` method:
+
+```python
+async def on_startup(app: Application):
+    error_forwarder = LogForwarder(
+        app.bot, [CHAT_ID], log_levels=["ERROR", "WARNING"]
+    )
+    # Add handler to the root logger to apply to all other loggers
+    logging.getLogger().addHandler(error_forwarder)
+```

--- a/ptbcontrib/log_forwarder/README.md
+++ b/ptbcontrib/log_forwarder/README.md
@@ -2,7 +2,7 @@
 Extension to forward application logs to specific Telegram chats through a `logging.Handler` class.
 
 ## Usage
-Initialize the log forwarder in your `on_startup` method:
+Initialize the log forwarder in a method that runs in the `post_init` hook of `Application`:
 
 ```python
 async def on_startup(app: Application):
@@ -11,4 +11,11 @@ async def on_startup(app: Application):
     )
     # Add handler to the root logger to apply to all other loggers
     logging.getLogger().addHandler(error_forwarder)
+
+application: Application = (
+    ApplicationBuilder()
+    .token("BOT_TOKEN")
+    .post_init(on_startup)
+    .build()
+)
 ```

--- a/ptbcontrib/log_forwarder/__init__.py
+++ b/ptbcontrib/log_forwarder/__init__.py
@@ -1,0 +1,25 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2024
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""
+This module contains a subclass for the `logging.Handler` that forwards specific logs to Telegram chats.
+"""
+
+from .log_forwarder import LogForwarder
+
+__all__ = [
+    "LogForwarder",
+]

--- a/ptbcontrib/log_forwarder/__init__.py
+++ b/ptbcontrib/log_forwarder/__init__.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """
-This module contains a subclass for the `logging.Handler` that forwards specific logs to Telegram chats.
+This module contains a subclass for the `logging.Handler`
+that forwards specific logs to Telegram chats.
 """
 
 from .log_forwarder import LogForwarder

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -25,7 +25,7 @@ class LogForwarder(logging.Handler):
         """
         Formats the log message to be sent to Telegram.
         Override this method to customize the message.
-        The default implementation applies the handler's formatter 
+        The default implementation applies the handler's formatter
         and puts the result in a Markdown code block.
         """
 

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -1,6 +1,6 @@
 import asyncio
+from collections.abc import Iterable
 import logging
-from typing_extensions import override
 from telegram.constants import ParseMode
 
 from telegram.ext import ExtBot
@@ -10,7 +10,7 @@ class LogForwarder(logging.Handler):
     def __init__(
         self,
         bot: ExtBot,
-        chat_ids: list[int],
+        chat_ids: Iterable[int],
         parse_mode: ParseMode = ParseMode.MARKDOWN_V2,
         log_levels: list[str] = ["WARN", "ERROR"],
     ):
@@ -29,7 +29,6 @@ class LogForwarder(logging.Handler):
         msg = "```\n" + text + "\n```"
         return msg
 
-    @override
     def emit(self, record):
         try:
             formatted = self.format(record)

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -11,7 +11,7 @@ class LogForwarder(logging.Handler):
         bot: ExtBot,
         chat_ids: Iterable[int],
         parse_mode: ParseMode = ParseMode.MARKDOWN_V2,
-        log_levels: list[str] = ["WARN", "ERROR"],
+        log_levels: Iterable[str] = ("WARN", "ERROR"),
     ):
         super().__init__()
         self._bot = bot
@@ -25,6 +25,7 @@ class LogForwarder(logging.Handler):
         Formats the log message to be sent to Telegram. Override this method to customize the message.
         The default implementation applies the handler's formatter and puts the result in a Markdown code block.
         """
+
         msg = "```\n" + text + "\n```"
         return msg
 
@@ -38,7 +39,7 @@ class LogForwarder(logging.Handler):
                         chat_id=chat_id, text=msg, parse_mode=self._parse_mode
                     )
                     asyncio.run_coroutine_threadsafe(f, self._loop)
-        except RecursionError:  # See issue 36272
+        except RecursionError:  # https://bugs.python.org/issue36272
             raise
         except Exception:
             self.handleError(record)

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -1,8 +1,7 @@
 import asyncio
-from collections.abc import Iterable
 import logging
+from collections.abc import Iterable
 from telegram.constants import ParseMode
-
 from telegram.ext import ExtBot
 
 
@@ -29,7 +28,7 @@ class LogForwarder(logging.Handler):
         msg = "```\n" + text + "\n```"
         return msg
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord):
         try:
             formatted = self.format(record)
             msg = self.format_tg_msg(formatted)

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -1,3 +1,21 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2024
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains LogForwarder class"""
+
 import asyncio
 import logging
 from collections.abc import Iterable
@@ -7,6 +25,10 @@ from telegram.ext import ExtBot
 
 
 class LogForwarder(logging.Handler):
+    """
+    Logging handler to forward specific logs to Telegram chats.
+    """
+
     def __init__(
         self,
         bot: ExtBot,
@@ -32,7 +54,7 @@ class LogForwarder(logging.Handler):
         msg = "```\n" + text + "\n```"
         return msg
 
-    def emit(self, record: logging.LogRecord):
+    def emit(self, record: logging.LogRecord) -> None:
         try:
             formatted = self.format(record)
             msg = self.format_tg_msg(formatted)
@@ -44,5 +66,5 @@ class LogForwarder(logging.Handler):
                     asyncio.run_coroutine_threadsafe(f, self._loop)
         except RecursionError:  # https://bugs.python.org/issue36272
             raise
-        except Exception:
+        except Exception:  # pylint: disable=W0703
             self.handleError(record)

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Iterable
+
 from telegram.constants import ParseMode
 from telegram.ext import ExtBot
 

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -23,8 +23,10 @@ class LogForwarder(logging.Handler):
 
     def format_tg_msg(self, text: str) -> str:
         """
-        Formats the log message to be sent to Telegram. Override this method to customize the message.
-        The default implementation applies the handler's formatter and puts the result in a Markdown code block.
+        Formats the log message to be sent to Telegram.
+        Override this method to customize the message.
+        The default implementation applies the handler's formatter 
+        and puts the result in a Markdown code block.
         """
 
         msg = "```\n" + text + "\n```"

--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -1,0 +1,46 @@
+import asyncio
+import logging
+from typing_extensions import override
+from telegram.constants import ParseMode
+
+from telegram.ext import ExtBot
+
+
+class LogForwarder(logging.Handler):
+    def __init__(
+        self,
+        bot: ExtBot,
+        chat_ids: list[int],
+        parse_mode: ParseMode = ParseMode.MARKDOWN_V2,
+        log_levels: list[str] = ["WARN", "ERROR"],
+    ):
+        super().__init__()
+        self._bot = bot
+        self._chat_ids = chat_ids
+        self._parse_mode = parse_mode
+        self._log_levels = log_levels
+        self._loop = asyncio.get_event_loop()
+
+    def format_tg_msg(self, text: str) -> str:
+        """
+        Formats the log message to be sent to Telegram. Override this method to customize the message.
+        The default implementation applies the handler's formatter and puts the result in a Markdown code block.
+        """
+        msg = "```\n" + text + "\n```"
+        return msg
+
+    @override
+    def emit(self, record):
+        try:
+            formatted = self.format(record)
+            msg = self.format_tg_msg(formatted)
+            if record.levelname in self._log_levels:
+                for chat_id in self._chat_ids:
+                    f = self._bot.send_message(
+                        chat_id=chat_id, text=msg, parse_mode=self._parse_mode
+                    )
+                    asyncio.run_coroutine_threadsafe(f, self._loop)
+        except RecursionError:  # See issue 36272
+            raise
+        except Exception:
+            self.handleError(record)

--- a/ptbcontrib/log_forwarder/requirements.txt
+++ b/ptbcontrib/log_forwarder/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot~=20.0

--- a/ptbcontrib/log_forwarder/requirements.txt
+++ b/ptbcontrib/log_forwarder/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot~=20.0
+python-telegram-bot>=20.0

--- a/tests/test_log_forwarder.py
+++ b/tests/test_log_forwarder.py
@@ -1,7 +1,7 @@
 import logging
+from unittest.mock import MagicMock
 from telegram.constants import ParseMode
 from ptbcontrib.log_forwarder import LogForwarder
-from unittest.mock import MagicMock
 
 
 async def test_log_forwarder():

--- a/tests/test_log_forwarder.py
+++ b/tests/test_log_forwarder.py
@@ -1,0 +1,19 @@
+from telegram.constants import ParseMode
+from ptbcontrib.log_forwarder import LogForwarder
+from unittest.mock import MagicMock
+import logging
+
+
+async def test_log_forwarder():
+    root_logger = logging.getLogger()
+    chat_ids = [69420]
+    bot = MagicMock()
+    log_forwarder = LogForwarder(bot, chat_ids)
+    root_logger.addHandler(log_forwarder)
+
+    logger = logging.getLogger("test_logger")
+    logger.error("TEST")
+
+    bot.send_message.assert_called_with(
+        chat_id=69420, text="```\nTEST\n```", parse_mode=ParseMode.MARKDOWN_V2
+    )

--- a/tests/test_log_forwarder.py
+++ b/tests/test_log_forwarder.py
@@ -1,7 +1,7 @@
+import logging
 from telegram.constants import ParseMode
 from ptbcontrib.log_forwarder import LogForwarder
 from unittest.mock import MagicMock
-import logging
 
 
 async def test_log_forwarder():

--- a/tests/test_log_forwarder.py
+++ b/tests/test_log_forwarder.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import MagicMock
+
 from telegram.constants import ParseMode
+
 from ptbcontrib.log_forwarder import LogForwarder
 
 


### PR DESCRIPTION
# Logging handler for python-telegram-bot
Extension to forward application logs to specific Telegram chats through a `logging.Handler` class.

## Usage
Initialize the log forwarder in your `on_startup` method:

```python
async def on_startup(app: Application):
    error_forwarder = LogForwarder(
        app.bot, [CHAT_ID], log_levels=["ERROR", "WARNING"]
    )
    # Add handler to the root logger to apply to all other loggers
    logging.getLogger().addHandler(error_forwarder)
```
