### PR TITLE
Fix tests for log-forwarder

### DIFF
--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains LogForwarder class"""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from collections.abc import Iterable


### PR DESCRIPTION
As far as a little testing locally goes, seems like the only issue is py3.8 not having `__class_getitem__` (aka: generic typing)

Thus `Iterable[T]` is not valid... As a quick fix, lets just force all hints to be strings via `annotations` and call it a day

CICD will let us know whether this deduction is actually correct.