### PR TITLE
import Iterable from typing module

### DIFF
--- a/ptbcontrib/log_forwarder/log_forwarder.py
+++ b/ptbcontrib/log_forwarder/log_forwarder.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Iterable
+from typing import Iterable
 
 from telegram.constants import ParseMode
 from telegram.ext import ExtBot


### PR DESCRIPTION
This fixes the error due to importing `Iterable` from `collections.abc.Iterable`