### PR TITLE
Extract passed user

### DIFF
--- a/ptbcontrib/extract_passed_user/README.md
+++ b/ptbcontrib/extract_passed_user/README.md
@@ -1,0 +1,53 @@
+from tests.test_extract_passed_user import shared_user
+
+# Extract passed user
+
+This module intended for a single function:   
+Extract side user from the message provided by current user.
+i.e. 1 user passes data of third-party user.
+
+Currently, the function will check:
+1. `Message.users_shared`
+2. `Message.contact`
+3. `Message.text` with numbers (if user id typed manually)
+4. `Message.text` with @name (if user @name typed manually)
+
+## Usage:
+
+1. By the users_shared: 
+```python
+Message=(..., users_shared)
+shared_user = extract_passed_user(message=message)  # Just the first user in the users_shared tuple 
+```
+
+2. By the contact:  
+Note: PTB `Contact.user_id` field is optional but required for the extraction or `None` otherwise will be returned. 
+```python
+Message=(..., contact=Contact(...))
+shared_user = extract_passed_user(message=message) 
+```
+
+3. By the text id: 
+```python
+Message=(..., text='Here my fried id - 123456, only numbers will be extracted.')
+shared_user = extract_passed_user(message=message) 
+```
+
+4. By the text @name:  
+Note: telegram bot API has no method to convert `@name` into `user_id`, 
+so ptbcontrlib module `username_to_chat_api` will be user for this.
+`username_resolver` parameter required for this, 
+it should be `UsernameToChatAPI` instance or custom async function.  
+The whole message text should contain only `@some_name` (Point to enhance in future releases).    
+```python
+Message=(..., text='@friend_nickname')
+shared_user = extract_passed_user(message=message, username_resolver=UsernameToChatAPI(..., )) 
+```
+
+## Requirements
+
+*   `python-telegram-bot>=21.1`
+
+## Authors
+
+*   [david Shiko](https://github.com/david-shiko)

--- a/ptbcontrib/extract_passed_user/README.md
+++ b/ptbcontrib/extract_passed_user/README.md
@@ -44,7 +44,8 @@ Message=(..., text='@friend_nickname')
 shared_user = extract_passed_user(message=message, username_resolver=UsernameToChatAPI(..., )) 
 ```
 
-### `get_num_from_text` - helper function which extracts first found number from the string as said in the docs above
+### `get_num_from_text` function:
+helper function which extracts first found number from the string as said in the docs above
 
 ## Requirements
 

--- a/ptbcontrib/extract_passed_user/README.md
+++ b/ptbcontrib/extract_passed_user/README.md
@@ -1,5 +1,3 @@
-from tests.test_extract_passed_user import shared_user
-
 # Extract passed user
 
 This module intended for a single function:   
@@ -14,35 +12,39 @@ Currently, the function will check:
 
 ## Usage:
 
-1. By the users_shared: 
+### 1. By the users_shared:
+Note: `users_shared` object is tuple and may contain many users but only first of them will be returned. 
 ```python
 Message=(..., users_shared)
 shared_user = extract_passed_user(message=message)  # Just the first user in the users_shared tuple 
 ```
 
-2. By the contact:  
+### 2. By the contact:  
 Note: PTB `Contact.user_id` field is optional but required for the extraction or `None` otherwise will be returned. 
 ```python
 Message=(..., contact=Contact(...))
 shared_user = extract_passed_user(message=message) 
 ```
 
-3. By the text id: 
+### 3. By the text id:   
+Note: Only first found number in the text will be used as `user_id`.
 ```python
 Message=(..., text='Here my fried id - 123456, only numbers will be extracted.')
 shared_user = extract_passed_user(message=message) 
 ```
 
-4. By the text @name:  
+### 4. By the text @name:  
 Note: telegram bot API has no method to convert `@name` into `user_id`, 
 so ptbcontrlib module `username_to_chat_api` will be user for this.
 `username_resolver` parameter required for this, 
 it should be `UsernameToChatAPI` instance or custom async function.  
-The whole message text should contain only `@some_name` (Point to enhance in future releases).    
+Only first found world with `@` prefix in the text will be used as future `user_id`.
 ```python
 Message=(..., text='@friend_nickname')
 shared_user = extract_passed_user(message=message, username_resolver=UsernameToChatAPI(..., )) 
 ```
+
+### `get_num_from_text` - helper function which extracts first found number from the string as said in the docs above
 
 ## Requirements
 

--- a/ptbcontrib/extract_passed_user/__init__.py
+++ b/ptbcontrib/extract_passed_user/__init__.py
@@ -18,4 +18,7 @@
 
 from .extract import extract_passed_user, get_nums_from_text
 
-__all__ = ["extract_passed_user", "get_nums_from_text", ]
+__all__ = [
+    "extract_passed_user",
+    "get_nums_from_text",
+]

--- a/ptbcontrib/extract_passed_user/__init__.py
+++ b/ptbcontrib/extract_passed_user/__init__.py
@@ -1,0 +1,21 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2025
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""This module contains a helper function to get joinable links from chats."""
+
+from .extract import extract_passed_user, get_nums_from_text
+
+__all__ = ["extract_passed_user", "get_nums_from_text", ]

--- a/ptbcontrib/extract_passed_user/__init__.py
+++ b/ptbcontrib/extract_passed_user/__init__.py
@@ -16,9 +16,9 @@
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """This module contains a helper function to get joinable links from chats."""
 
-from .extract import extract_passed_user, get_nums_from_text
+from .extract import extract_passed_user, get_num_from_text
 
 __all__ = [
     "extract_passed_user",
-    "get_nums_from_text",
+    "get_num_from_text",
 ]

--- a/ptbcontrib/extract_passed_user/extract.py
+++ b/ptbcontrib/extract_passed_user/extract.py
@@ -43,7 +43,7 @@ def get_num_from_text(
     return None
 
 
-def default_resolver(
+def _default_resolver(
     wrapper: UsernameToChatAPI,
     username: str,
 ) -> Chat | None:
@@ -78,7 +78,7 @@ async def extract_passed_user(
         return message.users_shared.users[0]
     if username_resolver and message.text and (username := re.search(r"@\S+", message.text)):
         if isinstance(username_resolver, UsernameToChatAPI):
-            chat = default_resolver(
+            chat = _default_resolver(
                 wrapper=username_resolver,
                 username=username.group(),
             )

--- a/ptbcontrib/extract_passed_user/extract.py
+++ b/ptbcontrib/extract_passed_user/extract.py
@@ -20,32 +20,47 @@
 """This module attempts to extract side user passed actual user from incoming message"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING, Callable
-import asyncio
 
-from telegram.error import TelegramError
+import asyncio
+from typing import TYPE_CHECKING, Callable
+
 from telegram import SharedUser
+from telegram.error import TelegramError
+
 from ..username_to_chat_api import UsernameToChatAPI
 
 if TYPE_CHECKING:
-    from telegram import Message, Chat
+    from telegram import Chat, Message
 
 
-def get_nums_from_text(text: str, ) -> int | None:
+def get_nums_from_text(
+    text: str,
+) -> int | None:
+    """Extract numbers from text"""
     try:
-        return int(''.join([letter for letter in text if letter.isdigit()]))
+        return int("".join([letter for letter in text if letter.isdigit()]))
     except ValueError:
         return None
 
 
-def default_resolver(wrapper: UsernameToChatAPI, username: str, ) -> Chat | None:
-    # Catch exceptions from username_to_chat_api ?
-    return asyncio.run(wrapper.resolve(username=username.strip(), ))
+def default_resolver(
+    wrapper: UsernameToChatAPI,
+    username: str,
+) -> Chat | None:
+    """
+    Try to resolve username to Chat object.
+    Catch exceptions from username_to_chat_api ?
+    """
+    return asyncio.run(
+        wrapper.resolve(
+            username=username.strip(),
+        )
+    )
 
 
 async def extract_passed_user(
-        message: Message,
-        username_resolver: Callable | UsernameToChatAPI | None = None,
+    message: Message,
+    username_resolver: Callable | UsernameToChatAPI | None = None,
 ) -> SharedUser | None:
     """
     4 cases:
@@ -58,37 +73,41 @@ async def extract_passed_user(
         1. `contact` may be without user_id.
         2. `contact` not contain @name at all, so not convertable to complete SharedUser.
     """
+    chat = user_id = None
     if message.users_shared:  # Note: May be select multiple
         return message.users_shared.users[0]
-    elif username_resolver and message.text and message.text.strip().startswith('@'):
+    if username_resolver and message.text and message.text.strip().startswith("@"):
         if isinstance(username_resolver, UsernameToChatAPI):
-            chat = default_resolver(wrapper=username_resolver, username=message.text, )
-        else:
-            chat: Chat | None = await username_resolver(username=message.text, )
-        if chat:
-            return SharedUser(
-                user_id=chat.id,
-                username=chat.username,
-                first_name=chat.first_name,
-                last_name=chat.last_name,
+            chat = default_resolver(
+                wrapper=username_resolver,
+                username=message.text,
             )
-        return None
-    elif hasattr(message.contact, 'user_id', ):
+        else:
+            chat: Chat | None = await username_resolver(  # type: ignore[no-redef]
+                username=message.text,
+            )
+    elif hasattr(
+        message.contact,
+        "user_id",
+    ):
         user_id = message.contact.user_id
     elif message.text:
-        user_id = get_nums_from_text(text=message.text, )
-    else:
-        return None  # pragma: no cover
+        user_id = get_nums_from_text(
+            text=message.text,
+        )
 
-    if not user_id:
-        return None  # pragma: no cover
-    try:
-        chat_info = (await message.get_bot().get_chat(chat_id=user_id, ))
-    except TelegramError:  # pragma: no cover
-        return None
-    return SharedUser(
-        user_id=chat_info.id,
-        username=chat_info.username,
-        first_name=chat_info.first_name,
-        last_name=chat_info.last_name,
-    )
+    if user_id:
+        try:
+            chat = await message.get_bot().get_chat(
+                chat_id=user_id,
+            )
+        except TelegramError:  # pragma: no cover
+            return None
+    if chat:
+        return SharedUser(
+            user_id=chat.id,
+            username=chat.username,
+            first_name=chat.first_name,
+            last_name=chat.last_name,
+        )
+    return None

--- a/ptbcontrib/extract_passed_user/extract.py
+++ b/ptbcontrib/extract_passed_user/extract.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2025
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+"""This module attempts to extract side user passed actual user from incoming message"""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Callable
+import asyncio
+
+from telegram.error import TelegramError
+from telegram import SharedUser
+from ..username_to_chat_api import UsernameToChatAPI
+
+if TYPE_CHECKING:
+    from telegram import Message, Chat
+
+
+def get_nums_from_text(text: str, ) -> int | None:
+    try:
+        return int(''.join([letter for letter in text if letter.isdigit()]))
+    except ValueError:
+        return None
+
+
+def default_resolver(wrapper: UsernameToChatAPI, username: str, ) -> Chat | None:
+    # Catch exceptions from username_to_chat_api ?
+    return asyncio.run(wrapper.resolve(username=username.strip(), ))
+
+
+async def extract_passed_user(
+        message: Message,
+        username_resolver: Callable | UsernameToChatAPI | None = None,
+) -> SharedUser | None:
+    """
+    4 cases:
+    1. message.users_shared
+    2. message.contact.user_id
+    3. message.text starts with '@' and resolved by wrapper
+    4. message.text has only numbers, resolved by get_nums_from_text
+
+    About contact entity:
+        1. `contact` may be without user_id.
+        2. `contact` not contain @name at all, so not convertable to complete SharedUser.
+    """
+    if message.users_shared:  # Note: May be select multiple
+        return message.users_shared.users[0]
+    elif username_resolver and message.text and message.text.strip().startswith('@'):
+        if isinstance(username_resolver, UsernameToChatAPI):
+            chat = default_resolver(wrapper=username_resolver, username=message.text, )
+        else:
+            chat: Chat | None = await username_resolver(username=message.text, )
+        if chat:
+            return SharedUser(
+                user_id=chat.id,
+                username=chat.username,
+                first_name=chat.first_name,
+                last_name=chat.last_name,
+            )
+        return None
+    elif hasattr(message.contact, 'user_id', ):
+        user_id = message.contact.user_id
+    elif message.text:
+        user_id = get_nums_from_text(text=message.text, )
+    else:
+        return None  # pragma: no cover
+
+    if not user_id:
+        return None  # pragma: no cover
+    try:
+        chat_info = (await message.get_bot().get_chat(chat_id=user_id, ))
+    except TelegramError:  # pragma: no cover
+        return None
+    return SharedUser(
+        user_id=chat_info.id,
+        username=chat_info.username,
+        first_name=chat_info.first_name,
+        last_name=chat_info.last_name,
+    )

--- a/ptbcontrib/extract_passed_user/requirements.txt
+++ b/ptbcontrib/extract_passed_user/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=21.1

--- a/ptbcontrib/roles/roles.py
+++ b/ptbcontrib/roles/roles.py
@@ -164,7 +164,7 @@ class Role(UpdateFilter):
 
     @staticmethod
     def _parse_child_role(
-        child_role: Union["Role", List["Role"], Tuple["Role", ...], None]
+        child_role: Union["Role", List["Role"], Tuple["Role", ...], None],
     ) -> Set["Role"]:
         if child_role is None:
             return set()

--- a/tests/test_extract_passed_user.py
+++ b/tests/test_extract_passed_user.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+#
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2025
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+
+from __future__ import annotations
+from functools import partial
+from datetime import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import create_autospec, patch, AsyncMock
+
+import pytest
+from telegram.constants import ChatType
+from telegram import Message, Chat, Contact, UsersShared, SharedUser
+from ptbcontrib.extract_passed_user import extract_passed_user, get_nums_from_text, extract
+from ptbcontrib.username_to_chat_api import UsernameToChatAPI
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+
+chat = Chat(id=1, type=ChatType.PRIVATE, username='username', first_name='first_name', last_name='last_name', )
+message_fabric = partial(Message,
+                         message_id=1,
+                         date=datetime.now(),
+                         chat=chat,
+                         )
+shared_user = SharedUser(user_id=1, username=chat.username, first_name=chat.first_name, last_name=chat.last_name, )
+
+class TestGetNumsFromText:
+    """test_get_nums_from_text"""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        argnames="text, expected",
+        argvalues=[
+            ("abc123xyz", 123),
+            ("98765", 98765),
+            ("abc9def8g7h6", 9876),
+        ]
+    )
+    def test_success(text: str, expected: int, ):
+        assert get_nums_from_text(text=text, ) == expected
+
+    @staticmethod
+    def test_exceptions():
+        for text in ("abcdef", ""):
+            assert get_nums_from_text(text=text, ) is None
+
+
+def test_default_resolver():
+    extract.default_resolver(
+        username='username',
+        wrapper=create_autospec(
+        spec=UsernameToChatAPI,
+        spec_set=True,
+        instance=False,
+    ))
+
+
+@pytest.fixture(scope='function', )
+def mock_message():
+    result = create_autospec(
+        spec=message_fabric(text='foo', ),
+        users_shared=None,
+        contact=None,
+        spec_set=True,
+    )
+    result.get_bot.return_value.get_chat = AsyncMock(spec_set=True, return_value=chat, )
+    yield result
+
+
+async def test_shared_user():
+    result = await extract_passed_user(
+        message=message_fabric(
+            users_shared=UsersShared(
+                request_id=1,
+                users=(shared_user,),
+            ), ),
+    )
+    assert result == shared_user
+
+
+async def test_text_username():
+    async def resolver(**_, ): return chat
+
+    result = await extract_passed_user(
+        message=message_fabric(
+            text='  @username ',
+        ),
+        username_resolver=resolver,
+    )
+    assert result == shared_user
+
+
+async def test_text_username_default_resolver():
+    with patch.object(
+            target=extract,
+            attribute='default_resolver',
+            autospec=True,
+            spec_set=True,
+            return_value=chat,
+    ):
+        result = await extract_passed_user(
+            message=message_fabric(
+                text='  @username ',
+            ),
+            username_resolver=create_autospec(
+                spec=UsernameToChatAPI,
+                spec_set=True,
+                instance=False,
+            ),
+        )
+        assert result == shared_user
+
+
+async def test_contact_with_user_id(mock_message: MagicMock, ):
+    mock_message.contact = Contact(phone_number='qwerty123', first_name='John', user_id=1, )
+    result = await extract_passed_user(
+        message=mock_message,
+    )
+    assert result == shared_user
+
+
+async def test_contact_without_user_id():
+    result = await extract_passed_user(
+        message=message_fabric(
+            contact=Contact(phone_number='qwerty123', first_name='John', ),
+            users_shared=None,
+        ),
+    )
+    assert result is None
+
+
+async def test_text_with_user_id(mock_message: MagicMock, ):
+    mock_message.text= ' qwerty123 bla bla 456 '
+    result = await extract_passed_user(
+        message=mock_message,
+    )
+    assert result == shared_user

--- a/tests/test_extract_passed_user.py
+++ b/tests/test_extract_passed_user.py
@@ -28,12 +28,11 @@ import pytest
 from telegram import Chat, Contact, Message, SharedUser, UsersShared
 from telegram.constants import ChatType
 
-from ptbcontrib.extract_passed_user import extract, extract_passed_user, get_nums_from_text
+from ptbcontrib.extract_passed_user import extract, extract_passed_user, get_num_from_text
 from ptbcontrib.username_to_chat_api import UsernameToChatAPI
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
-
 
 chat = Chat(
     id=1,
@@ -65,7 +64,7 @@ class TestGetNumsFromText:
         argvalues=[
             ("abc123xyz", 123),
             ("98765", 98765),
-            ("abc9def8g7h6", 9876),
+            ("  ab#$@c9def8g7h6 ", 9),
         ],
     )
     def test_success(
@@ -73,7 +72,7 @@ class TestGetNumsFromText:
         expected: int,
     ):
         assert (
-            get_nums_from_text(
+            get_num_from_text(
                 text=text,
             )
             == expected
@@ -83,7 +82,7 @@ class TestGetNumsFromText:
     def test_exceptions():
         for text in ("abcdef", ""):
             assert (
-                get_nums_from_text(
+                get_num_from_text(
                     text=text,
                 )
                 is None
@@ -140,7 +139,7 @@ async def test_text_username():
 
     result = await extract_passed_user(
         message=message_fabric(
-            text="  @username ",
+            text="  foo 434 @username @second_user ",
         ),
         username_resolver=resolver,
     )

--- a/tests/test_extract_passed_user.py
+++ b/tests/test_extract_passed_user.py
@@ -90,7 +90,7 @@ class TestGetNumsFromText:
 
 
 def test_default_resolver():
-    extract.default_resolver(
+    extract._default_resolver(
         username="username",
         wrapper=create_autospec(
             spec=UsernameToChatAPI,
@@ -149,7 +149,7 @@ async def test_text_username():
 async def test_text_username_default_resolver():
     with patch.object(
         target=extract,
-        attribute="default_resolver",
+        attribute="_default_resolver",
         autospec=True,
         spec_set=True,
         return_value=chat,


### PR DESCRIPTION
This module is intended for a single purpose:
Extracting the side user's information from the message provided by the current user. 
For instance, User 1 passes data about User 2 (who could be their friend).  

P.S. In this code, I utilize the `UsernameToChatAPI` module, but I personally have no idea how to use it and simply delegate its execution. In my own code, I merely utilized Telethon's methods with public available hash and an app ID.