### PR TITLE
feat(postgres_persistence): add single-row constraint with auto-migration

### DIFF
--- a/ptbcontrib/postgres_persistence/README.md
+++ b/ptbcontrib/postgres_persistence/README.md
@@ -47,3 +47,6 @@ application = Application.builder().token(...).persistence(PostgresPersistence(s
 
 *   [Stɑrry Shivɑm](https://github.com/starry69)
 
+## Contributors
+
+*   [Chin Rong Ong](https://github.com/crong12)

--- a/ptbcontrib/postgres_persistence/postgrespersistence.py
+++ b/ptbcontrib/postgres_persistence/postgrespersistence.py
@@ -89,8 +89,10 @@ class PostgresPersistence(DictPersistence):
             # can perform `UPDATE` operations on it, cause SQL only allows
             # `UPDATE` operations if column have some data already present inside it.
             if not data:
-                insert_qry = "INSERT INTO persistence (data) VALUES (:jsondata)"
-                self._session.execute(text(insert_qry), {"jsondata": "{}"})
+                upsert_qry = """
+                INSERT INTO persistence (data) VALUES (:jsondata)
+                ON CONFLICT (id) DO UPDATE SET data = :jsondata"""
+                self._session.execute(text(upsert_qry), {"jsondata": "{}"})
                 self._session.commit()
 
             super().__init__(
@@ -108,16 +110,48 @@ class PostgresPersistence(DictPersistence):
         """
         creates table for storing the data if table
         doesn't exist already inside database.
+        runs schema migration if necessary.
         """
-        create_table_qry = """
-            CREATE TABLE IF NOT EXISTS persistence(
-            data json NOT NULL);"""
-        self._session.execute(text(create_table_qry))
-        self._session.commit()
+        try:
+            create_table_qry = """
+                CREATE TABLE IF NOT EXISTS persistence(
+                id INT PRIMARY KEY DEFAULT 1,
+                data json NOT NULL,
+                CONSTRAINT single_row CHECK (id = 1));"""
+            self._session.execute(text(create_table_qry))
+
+            check_column_qry = """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'persistence' AND column_name = 'id';"""
+            needs_migration = self._session.execute(text(check_column_qry)).first() is None
+
+            if needs_migration:
+                self.logger.info("Old database schema detected. Running migration...")
+                migration_commands = [
+                    "ALTER TABLE persistence ADD COLUMN id INT;",
+                    """
+                    UPDATE persistence SET id = 1 WHERE ctid = (
+                        SELECT ctid FROM persistence LIMIT 1
+                    );""",
+                    "DELETE FROM persistence WHERE id IS NULL;",
+                    "ALTER TABLE persistence ALTER COLUMN id SET NOT NULL;",
+                    "ALTER TABLE persistence ADD PRIMARY KEY (id);",
+                    "ALTER TABLE persistence ADD CONSTRAINT single_row CHECK (id = 1);",
+                ]
+                for command in migration_commands:
+                    self._session.execute(text(command))
+                self.logger.info("Database migration successful!")
+
+            self._session.commit()
+        except Exception as excp:  # pylint: disable=W0703
+            self.logger.error(
+                "Database initialization or migration failed!",
+                exc_info=excp,
+            )
+            self._session.rollback()
 
     def _dump_into_json(self) -> Any:
         """Dumps data into json format for inserting in db."""
-
         to_dump = {
             "chat_data": self.chat_data_json,
             "user_data": self.user_data_json,
@@ -131,16 +165,18 @@ class PostgresPersistence(DictPersistence):
     def _update_database(self) -> None:
         self.logger.debug("Updating database...")
         try:
-            insert_qry = "UPDATE persistence SET data = :jsondata"
+            upsert_qry = """
+            INSERT INTO persistence (data) VALUES (:jsondata)
+            ON CONFLICT (id) DO UPDATE SET data = :jsondata"""
             params = {"jsondata": self._dump_into_json()}
-            self._session.execute(text(insert_qry), params)
+            self._session.execute(text(upsert_qry), params)
             self._session.commit()
         except Exception as excp:  # pylint: disable=W0703
-            self._session.close()
             self.logger.error(
                 "Failed to save data in the database.\nLogging exception: ",
                 exc_info=excp,
             )
+            self._session.rollback()
 
     async def update_conversation(
         self, name: str, key: Tuple[int, ...], new_state: Optional[object]

--- a/tests/test_postgres_persistence.py
+++ b/tests/test_postgres_persistence.py
@@ -55,7 +55,7 @@ class TestPostgresPersistence:
         self.ses_closed = False
         self.flush_flag = False
 
-    def mocked_execute(self, query, *args, **kwargs):
+    def mocked_execute(self, query, params=None):  # pylint: disable=unused-argument
         self.executed = query
         return FakeExecResult()
 
@@ -172,14 +172,16 @@ class TestPostgresPersistence:
         monkeypatch.setattr(session, "close", self.mock_ses_close)
 
         PostgresPersistence(session=session)
-        assert self.executed.text in {
-            "SELECT data FROM persistence",
-            "INSERT INTO persistence (data) VALUES (:jsondata)",
-        }
+        # Check that either SELECT or UPSERT query was executed (upsert for fresh db)
+        executed_text = self.executed.text.strip()
+        assert "SELECT data FROM persistence" in executed_text or (
+            "INSERT INTO persistence (data) VALUES (:jsondata)" in executed_text
+            and "ON CONFLICT (id) DO UPDATE SET data = :jsondata" in executed_text
+        )
         assert self.commited == 555
         assert self.ses_closed is True
 
-    async def test_flush(self, bot, update, monkeypatch):
+    async def test_flush(self, monkeypatch):
         session = scoped_session("a")
         monkeypatch.setattr(session, "execute", self.mocked_execute)
         monkeypatch.setattr(session, "commit", self.mock_commit)
@@ -188,3 +190,283 @@ class TestPostgresPersistence:
         await PostgresPersistence(session=session).flush()
         assert self.executed != ""
         assert self.commited == 555
+
+    def test_new_schema_creation(self, monkeypatch):
+        """Test that new tables are created with id column and single_row constraint"""
+        executed_queries = []
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Check that CREATE TABLE was called with new schema
+        create_table_found = any(
+            "CREATE TABLE IF NOT EXISTS persistence" in query for query in executed_queries
+        )
+        assert create_table_found
+
+        # Check that the schema includes id column and constraint
+        create_table_query = next(
+            q for q in executed_queries if "CREATE TABLE IF NOT EXISTS persistence" in q
+        )
+        assert "id INT PRIMARY KEY DEFAULT 1" in create_table_query
+        assert "CONSTRAINT single_row CHECK (id = 1)" in create_table_query
+
+    def test_schema_migration_detection(self, monkeypatch):
+        """Test that old schema without id column is detected"""
+        executed_queries = []
+
+        class FakeExecResultWithColumn:
+            """Simulates that id column exists (no migration needed)"""
+
+            def first(self):
+                return (1,)  # Column exists
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            # Check if this is the column check query
+            if "information_schema.columns" in query.text and "column_name = 'id'" in query.text:
+                return FakeExecResultWithColumn()
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Verify no migration commands were run
+        migration_commands = [
+            "ALTER TABLE persistence ADD COLUMN id INT",
+            "UPDATE persistence SET id = 1",
+            "DELETE FROM persistence WHERE id IS NULL",
+        ]
+        for migration_cmd in migration_commands:
+            assert not any(migration_cmd in query for query in executed_queries)
+
+    def test_schema_migration_execution(self, monkeypatch):
+        """Test that migration is executed when old schema is detected"""
+        executed_queries = []
+
+        class FakeExecResultNoColumn:
+            """Simulates that id column doesn't exist (migration needed)"""
+
+            def first(self):
+                return None  # Column doesn't exist
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            # Check if this is the column check query
+            if "information_schema.columns" in query.text and "column_name = 'id'" in query.text:
+                return FakeExecResultNoColumn()
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Verify migration commands were run in correct order
+        expected_migration_steps = [
+            "ALTER TABLE persistence ADD COLUMN id INT",
+            "UPDATE persistence SET id = 1",
+            "DELETE FROM persistence WHERE id IS NULL",
+            "ALTER TABLE persistence ALTER COLUMN id SET NOT NULL",
+            "ALTER TABLE persistence ADD PRIMARY KEY (id)",
+            "ALTER TABLE persistence ADD CONSTRAINT single_row CHECK (id = 1)",
+        ]
+
+        for expected_step in expected_migration_steps:
+            assert any(
+                expected_step in query for query in executed_queries
+            ), f"Expected migration step not found: {expected_step}"
+
+    def test_upsert_query_on_fresh_database(self, monkeypatch):
+        """Test that upsert query is used when initializing fresh database"""
+        executed_queries = []
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Check that upsert query was used for initialization
+        upsert_found = any(
+            "INSERT INTO persistence (data) VALUES (:jsondata)" in query
+            and "ON CONFLICT (id) DO UPDATE SET data = :jsondata" in query
+            for query in executed_queries
+        )
+        assert upsert_found
+
+    def test_upsert_query_on_update(self, monkeypatch):
+        """Test that upsert query is used when updating database"""
+        executed_queries = []
+        executed_params = []
+
+        def mock_execute(query, params=None):
+            executed_queries.append(query.text)
+            if params:
+                executed_params.append(params)
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+        monkeypatch.setattr(session, "rollback", lambda: None)
+
+        persistence = PostgresPersistence(session=session)
+
+        # Clear previous queries
+        executed_queries.clear()
+        executed_params.clear()
+
+        # Trigger update  # pylint: disable=protected-access
+        persistence._update_database()
+
+        # Verify upsert query was used
+        upsert_found = any(
+            "INSERT INTO persistence (data) VALUES (:jsondata)" in query
+            and "ON CONFLICT (id) DO UPDATE SET data = :jsondata" in query
+            for query in executed_queries
+        )
+        assert upsert_found
+
+        # Verify parameters were passed
+        assert len(executed_params) > 0
+        assert "jsondata" in executed_params[0]
+
+    def test_single_row_constraint_in_schema(self, monkeypatch):
+        """Test that single_row constraint is present in schema"""
+        executed_queries = []
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Find the CREATE TABLE query
+        create_table_query = next(
+            (q for q in executed_queries if "CREATE TABLE IF NOT EXISTS persistence" in q), None
+        )
+
+        assert create_table_query is not None
+        assert "CONSTRAINT single_row CHECK (id = 1)" in create_table_query
+
+    def test_migration_preserves_single_row(self, monkeypatch):
+        """Test that migration deletes extra rows and keeps only one"""
+        executed_queries = []
+
+        class FakeExecResultNoColumn:
+            def first(self):
+                return None
+
+        def mock_execute(query, params=None):  # pylint: disable=unused-argument
+            executed_queries.append(query.text)
+            if "information_schema.columns" in query.text and "column_name = 'id'" in query.text:
+                return FakeExecResultNoColumn()
+            return FakeExecResult()
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        PostgresPersistence(session=session)
+
+        # Verify that migration includes step to update first row to id=1
+        update_first_row = any(
+            "UPDATE persistence SET id = 1" in query and "LIMIT 1" in query
+            for query in executed_queries
+        )
+        assert update_first_row
+
+        # Verify that migration deletes rows without id
+        delete_extra_rows = any(
+            "DELETE FROM persistence WHERE id IS NULL" in query for query in executed_queries
+        )
+        assert delete_extra_rows
+
+    async def test_data_persistence_with_upsert(self, bot, update, monkeypatch):
+        """Test that data is correctly persisted using upsert"""
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", self.mocked_execute)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+
+        app = (
+            Application.builder()
+            .bot(DictExtBot(bot.token))
+            .persistence(PostgresPersistence(session=session))
+            .build()
+        )
+
+        async def handler(upd, context):  # pylint: disable=unused-argument
+            context.user_data["key"] = "value"
+            context.chat_data["chat_key"] = "chat_value"
+            context.bot_data["bot_key"] = "bot_value"
+
+        h = MessageHandler(None, handler)
+        app.add_handler(h)
+
+        async with app:
+            await app.process_update(update)
+
+        # Verify that update was executed
+        assert self.executed != ""
+        assert self.commited == 555
+
+    def test_migration_error_handling(self, monkeypatch):
+        """Test that migration errors are handled gracefully"""
+
+        class FakeExecResultNoColumn:
+            def first(self):
+                return None
+
+        def mock_execute_with_error(query, params=None):  # pylint: disable=unused-argument
+            if "information_schema.columns" in query.text:
+                return FakeExecResultNoColumn()
+            # Simulate error during migration
+            if "ALTER TABLE" in query.text:
+                raise RuntimeError("Migration failed")
+            return FakeExecResult()
+
+        rollback_called = False
+
+        def mock_rollback():
+            nonlocal rollback_called
+            rollback_called = True
+
+        session = scoped_session("a")
+        monkeypatch.setattr(session, "execute", mock_execute_with_error)
+        monkeypatch.setattr(session, "commit", self.mock_commit)
+        monkeypatch.setattr(session, "close", self.mock_ses_close)
+        monkeypatch.setattr(session, "rollback", mock_rollback)
+
+        # Should not raise exception, but handle it gracefully
+        PostgresPersistence(session=session)
+
+        # Verify rollback was called
+        assert rollback_called


### PR DESCRIPTION
Purpose of branch: add single-row constraint with auto-migration for postgres_persistence implementation.

Context: current implementation may cause race condition, resulting in multiple duplicated rows being inserted into the persistence table. 

Changes in this commit: 
- enforce single-row persistence table using id column with CHECK constraint. 
- replace INSERT query with UPSERT. 
- add automatic migration from old schema with full backward compatibility (includes comprehensive test coverage).