### PR TITLE
fix a constraint violation bug in postgres_persistence.

### DIFF
--- a/tests/test_postgres_persistence.py
+++ b/tests/test_postgres_persistence.py
@@ -252,7 +252,7 @@ class TestPostgresPersistence:
                 return FakeExecResultValidPK()
 
             # Check for data validation query (id=1 exists)
-            if "WHERE id = 1" in query.text and "information_schema" not in query.text:
+            if "WHERE id = :id" in query.text and "information_schema" not in query.text:
                 return FakeExecResultValidData()
 
             return FakeExecResult()
@@ -267,7 +267,7 @@ class TestPostgresPersistence:
         # Verify no migration commands were run
         migration_commands = [
             "ALTER TABLE persistence ADD COLUMN id INT",
-            "UPDATE persistence SET id = 1",
+            "UPDATE persistence SET id = :id",
             "DELETE FROM persistence WHERE id IS NULL",
         ]
         for migration_cmd in migration_commands:
@@ -347,11 +347,11 @@ class TestPostgresPersistence:
         # Verify migration commands were run in correct order
         expected_migration_steps = [
             "ALTER TABLE persistence ADD COLUMN id INT",
-            "UPDATE persistence SET id = 1",
+            "UPDATE persistence SET id = :id",
             "DELETE FROM persistence WHERE id IS NULL",
             "ALTER TABLE persistence ALTER COLUMN id SET NOT NULL",
             "ALTER TABLE persistence ADD PRIMARY KEY (id)",
-            "ALTER TABLE persistence ADD CONSTRAINT single_row CHECK (id = 1)",
+            "ALTER TABLE persistence ADD CONSTRAINT single_row CHECK (id = :id)",
         ]
 
         for expected_step in expected_migration_steps:
@@ -500,7 +500,7 @@ class TestPostgresPersistence:
 
         # Verify that migration includes step to update first row to id=1
         update_first_row = any(
-            "UPDATE persistence SET id = 1" in query and "LIMIT 1" in query
+            "UPDATE persistence SET id = :id" in query and "LIMIT 1" in query
             for query in executed_queries
         )
         assert update_first_row


### PR DESCRIPTION
context: this PR is related to #137, fixing a bug that's caused by a constraint violation on the id column in the persistence table. 

key change: explicitly provide id value in upsert query to avoid constraint violation issue. 