### PR TITLE
Add true reply filter

### DIFF
--- a/ptbcontrib/true_reply_filter/README.md
+++ b/ptbcontrib/true_reply_filter/README.md
@@ -1,0 +1,21 @@
+# True Reply Filter
+
+Provides a `TRUE_REPLY_FILTER` that allows you to filter only **real replies** in Telegram groups and forum topics, ignoring topic starters.
+
+```python
+from telegram.ext import MessageHandler
+from ptbcontrib.true_reply_filter import TRUE_REPLY_FILTER
+
+MessageHandler(
+    TRUE_REPLY_FILTER,
+    callback
+)
+```
+
+## Requirements
+
+*   `python-telegram-bot>=20.0`
+
+## Authors
+
+*   [Daniel](https://github.com/rozari0)

--- a/ptbcontrib/true_reply_filter/__init__.py
+++ b/ptbcontrib/true_reply_filter/__init__.py
@@ -1,0 +1,25 @@
+# A library containing community-based extension for the python-telegram-bot library
+# Copyright (C) 2020-2026
+# The ptbcontrib developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser Public License for more details.
+#
+# You should have received a copy of the GNU Lesser Public License
+# along with this program.  If not, see [http://www.gnu.org/licenses/].
+"""
+This module contains a filter that filters correctly in a group with topics.
+"""
+
+from .true_reply_filter import TRUE_REPLY_FILTER
+
+__all__ = [
+    "TRUE_REPLY_FILTER",
+]

--- a/ptbcontrib/true_reply_filter/requirements.txt
+++ b/ptbcontrib/true_reply_filter/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=20.0

--- a/ptbcontrib/true_reply_filter/true_reply_filter.py
+++ b/ptbcontrib/true_reply_filter/true_reply_filter.py
@@ -1,0 +1,19 @@
+from telegram import Message
+from telegram.ext.filters import MessageFilter
+
+
+class _Reply(MessageFilter):
+    __slots__ = ()
+
+    def filter(self, message: Message) -> bool:
+        if not message.reply_to_message:
+            return False
+        if (
+            message.is_topic_message
+            and message.message_thread_id == message.reply_to_message.message_id
+        ):
+            return False
+        return True
+
+
+TRUE_REPLY_FILTER = _Reply(name="true_reply_filter.REPLY")


### PR DESCRIPTION
Telegram API sends the topic creation message as reply_to_message for every message in a topic, which causes bots to treat every message as a reply.

This filter checks if a message is in a topic and then verifies whether the message_thread_id is the same as the topic creation message ID.


